### PR TITLE
fix: uncomment files from gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -152,10 +152,10 @@ fabric.properties
 ### Intellij Patch ###
 # Comment Reason: https://github.com/joeblau/gitignore.io/issues/186#issuecomment-215987721
 
-# *.iml
-# modules.xml
+*.iml
+modules.xml
 .idea/misc.xml
-# *.ipr
+*.ipr
 
 # Sonarlint plugin
 # https://plugins.jetbrains.com/plugin/7973-sonarlint

--- a/.gitignore
+++ b/.gitignore
@@ -154,7 +154,7 @@ fabric.properties
 
 # *.iml
 # modules.xml
-# .idea/misc.xml
+.idea/misc.xml
 # *.ipr
 
 # Sonarlint plugin


### PR DESCRIPTION
For `misc.xml` file, since our team doesn't share jdk manager this should be ignored as it contains local settings which could be different among the team.

And check another files at https://intellij-support.jetbrains.com/hc/en-us/articles/206544839-How-to-manage-projects-under-Version-Control-Systems

But let's not ignore the whole `.idea/` for now.