### PR TITLE
feat: additional domain change

### DIFF
--- a/api/build.gradle
+++ b/api/build.gradle
@@ -16,6 +16,7 @@ repositories {
 dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+    implementation 'org.springframework.boot:spring-boot-starter-security'
     implementation 'org.postgresql:postgresql'
     compileOnly 'org.projectlombok:lombok'
     annotationProcessor 'org.projectlombok:lombok'

--- a/api/src/main/java/com/thesurvey/api/controller/SurveyController.java
+++ b/api/src/main/java/com/thesurvey/api/controller/SurveyController.java
@@ -4,6 +4,7 @@ import com.thesurvey.api.domain.Survey;
 import com.thesurvey.api.service.SurveyService;
 import java.util.List;
 import java.util.Optional;
+import java.util.UUID;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -28,7 +29,7 @@ public class SurveyController {
         return ResponseEntity.ok(surveyList);
     }
     @GetMapping("/{surveyId}")
-    public ResponseEntity<Optional<Survey>> getSurveyWithId(@PathVariable Long surveyId) {
+    public ResponseEntity<Optional<Survey>> getSurveyWithId(@PathVariable UUID surveyId) {
         Optional<Survey> survey = surveyService.getSurveyById(surveyId);
         return ResponseEntity.ok(survey);
     }

--- a/api/src/main/java/com/thesurvey/api/controller/UserController.java
+++ b/api/src/main/java/com/thesurvey/api/controller/UserController.java
@@ -1,5 +1,6 @@
 package com.thesurvey.api.controller;
 
+import com.thesurvey.api.domain.User;
 import com.thesurvey.api.dto.UserDto;
 import com.thesurvey.api.service.UserService;
 import java.util.List;
@@ -20,11 +21,6 @@ public class UserController {
         this.userService = userService;
     }
 
-    @PostMapping
-    public ResponseEntity<String> join(@RequestBody UserDto userDto) {
-        userService.join(userDto);
-        return ResponseEntity.ok().body("Success sign up");
-    }
     @GetMapping
     public ResponseEntity<List<UserDto>> getAllUsersWithAnsweredQuestions(){
         return ResponseEntity.ok(userService.getAllUsersWithAnsweredQuestion());

--- a/api/src/main/java/com/thesurvey/api/domain/BaseTimeEntity.java
+++ b/api/src/main/java/com/thesurvey/api/domain/BaseTimeEntity.java
@@ -1,0 +1,25 @@
+package com.thesurvey.api.domain;
+
+import java.time.LocalDateTime;
+import javax.persistence.Column;
+import javax.persistence.EntityListeners;
+import javax.persistence.MappedSuperclass;
+import lombok.Getter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+@Getter
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
+public abstract class BaseTimeEntity {
+
+    @CreatedDate
+    @Column(name = "created_date", nullable = false)
+    private LocalDateTime createdDate;
+
+    @LastModifiedDate
+    @Column(name = "modified_date")
+    private LocalDateTime modifiedDate;
+
+}

--- a/api/src/main/java/com/thesurvey/api/domain/Role.java
+++ b/api/src/main/java/com/thesurvey/api/domain/Role.java
@@ -1,0 +1,6 @@
+package com.thesurvey.api.domain;
+
+public enum Role {
+    USER,
+    ADMIN
+}

--- a/api/src/main/java/com/thesurvey/api/domain/Survey.java
+++ b/api/src/main/java/com/thesurvey/api/domain/Survey.java
@@ -1,9 +1,9 @@
 package com.thesurvey.api.domain;
 
 import com.fasterxml.jackson.annotation.JsonManagedReference;
-import java.sql.Timestamp;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.UUID;
 import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.FetchType;
@@ -26,12 +26,14 @@ public class Survey {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "survey_id")
-    private Long surveyId;
+    private UUID surveyId;
     @Column(name = "title", nullable = false)
     private String title;
-    @Column(name = "created_date", nullable = false)
-    private Timestamp createdDate;
-    @OneToMany(mappedBy = "survey", fetch = FetchType.EAGER, orphanRemoval = true)
+
+    @Column(name = "description", nullable = false)
+    private String description;
+
+    @OneToMany(mappedBy = "survey", fetch = FetchType.EAGER)
     @JsonManagedReference
     private List<Question> questions;
 
@@ -39,11 +41,11 @@ public class Survey {
     private List<Participation> participations = new ArrayList<>();
 
     @Builder
-    public Survey(Long surveyId, String title, List<Question> questions, Timestamp createdDate, List<Participation> participations) {
-        this.surveyId = surveyId;
+    public Survey(String title, String description, List<Question> questions,
+        List<Participation> participations) {
         this.title = title;
+        this.description = description;
         this.questions = questions;
-        this.createdDate = createdDate;
         this.participations = participations;
     }
 

--- a/api/src/main/java/com/thesurvey/api/domain/Survey.java
+++ b/api/src/main/java/com/thesurvey/api/domain/Survey.java
@@ -21,7 +21,7 @@ import lombok.NoArgsConstructor;
 @Table(name = "survey")
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class Survey {
+public class Survey extends BaseTimeEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/api/src/main/java/com/thesurvey/api/domain/User.java
+++ b/api/src/main/java/com/thesurvey/api/domain/User.java
@@ -1,9 +1,12 @@
 package com.thesurvey.api.domain;
 
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.List;
 import javax.persistence.Column;
 import javax.persistence.Entity;
+import javax.persistence.EnumType;
+import javax.persistence.Enumerated;
 import javax.persistence.FetchType;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
@@ -14,12 +17,15 @@ import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
 
 @Entity
 @Table(name = "users")
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class User {
+public class User extends BaseTimeEntity implements UserDetails {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -28,6 +34,10 @@ public class User {
 
     @Column(name = "email", nullable = false)
     private String email;
+
+    @Column(name = "password", nullable = false)
+    private String password;
+
     @Column(name = "name", nullable = false)
     private String name;
     @OneToMany(mappedBy = "user", fetch = FetchType.LAZY)
@@ -35,14 +45,52 @@ public class User {
     @OneToMany(mappedBy = "user")
     private List<AnsweredQuestion> answeredQuestions = new ArrayList<>();
 
+
     @Builder
-    public User(Long userId, String email, String name, List<Participation> participations,
+    public User(String email, String name, Role role, String password,
         List<AnsweredQuestion> answeredQuestions) {
-        this.userId = userId;
         this.email = email;
         this.name = name;
-        this.participations = participations;
+        this.role = role;
+        this.password = password;
         this.answeredQuestions = answeredQuestions;
     }
 
+    @Enumerated(EnumType.STRING)
+    private Role role;
+
+    @Override
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+        return List.of(new SimpleGrantedAuthority(role.name()));
+    }
+
+    @Override
+    public String getUsername() {
+        return name;
+    }
+
+    @Override
+    public String getPassword() {
+        return password;
+    }
+
+    @Override
+    public boolean isAccountNonExpired() {
+        return true;
+    }
+
+    @Override
+    public boolean isAccountNonLocked() {
+        return true;
+    }
+
+    @Override
+    public boolean isCredentialsNonExpired() {
+        return true;
+    }
+
+    @Override
+    public boolean isEnabled() {
+        return true;
+    }
 }

--- a/api/src/main/java/com/thesurvey/api/dto/SurveyDto.java
+++ b/api/src/main/java/com/thesurvey/api/dto/SurveyDto.java
@@ -1,39 +1,23 @@
 package com.thesurvey.api.dto;
 
+import com.thesurvey.api.domain.Participation;
 import com.thesurvey.api.domain.Question;
-import com.thesurvey.api.domain.Survey;
-import java.sql.Timestamp;
 import java.util.List;
+import java.util.UUID;
 import lombok.Builder;
 import lombok.Getter;
-import lombok.NoArgsConstructor;
-import lombok.Setter;
 
 @Getter
-@NoArgsConstructor
+@Builder
 public class SurveyDto {
 
+    private UUID surveyId;
+
     private String title;
+
+    private String description;
+
     private List<Question> questions;
-    private Timestamp createdDate;
 
-    public SurveyDto(Survey survey) {
-        this.title = survey.getTitle();
-        this.questions = survey.getQuestions();
-        this.createdDate = survey.getCreatedDate();
-    }
-
-    @Builder
-    public SurveyDto(String title, List<Question> questions, Timestamp createdDate) {
-        this.title = title;
-        this.questions = questions;
-        this.createdDate = createdDate;
-    }
-
-    public Survey toEntity() {
-        return Survey.builder().title(this.getTitle())
-            .questions(this.getQuestions())
-            .createdDate(this.getCreatedDate())
-            .build();
-    }
+    private List<Participation> participations;
 }

--- a/api/src/main/java/com/thesurvey/api/dto/UserDto.java
+++ b/api/src/main/java/com/thesurvey/api/dto/UserDto.java
@@ -1,6 +1,7 @@
 package com.thesurvey.api.dto;
 
 import com.thesurvey.api.domain.AnsweredQuestion;
+import com.thesurvey.api.domain.Participation;
 import com.thesurvey.api.domain.Role;
 import java.util.List;
 import lombok.AllArgsConstructor;
@@ -23,5 +24,7 @@ public class UserDto {
     private Role role;
 
     private List<AnsweredQuestion> answeredQuestions;
+
+    private List<Participation> participations;
 
 }

--- a/api/src/main/java/com/thesurvey/api/dto/UserDto.java
+++ b/api/src/main/java/com/thesurvey/api/dto/UserDto.java
@@ -1,29 +1,27 @@
 package com.thesurvey.api.dto;
 
-import com.thesurvey.api.domain.User;
+import com.thesurvey.api.domain.AnsweredQuestion;
+import com.thesurvey.api.domain.Role;
+import java.util.List;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import org.springframework.beans.factory.annotation.Autowired;
 
 @Getter
+@Builder
+@AllArgsConstructor
 @NoArgsConstructor
 public class UserDto {
 
-    public String name;
-    public String email;
+    private String name;
 
-    public UserDto (User user) {
-        this.name = user.getName();
-        this.email = user.getEmail();
-    }
-    @Builder
-    public UserDto (String name, String email) {
-        this.name = name;
-        this.email = email;
-    }
-    public User toEntity() {
-        return User.builder().name(this.getName()).email(this.getEmail()).build();
-    }
+    private String email;
+
+    private String password;
+
+    private Role role;
+
+    private List<AnsweredQuestion> answeredQuestions;
+
 }

--- a/api/src/main/java/com/thesurvey/api/dto/UserInfoDto.java
+++ b/api/src/main/java/com/thesurvey/api/dto/UserInfoDto.java
@@ -1,0 +1,16 @@
+package com.thesurvey.api.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class UserInfoDto {
+
+    private Long userId;
+
+    private String email;
+
+    private String name;
+
+}

--- a/api/src/main/java/com/thesurvey/api/repository/SurveyRepository.java
+++ b/api/src/main/java/com/thesurvey/api/repository/SurveyRepository.java
@@ -3,11 +3,12 @@ package com.thesurvey.api.repository;
 import com.thesurvey.api.domain.Survey;
 import java.util.List;
 import java.util.Optional;
+import java.util.UUID;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
-public interface SurveyRepository extends JpaRepository<Survey, Long> {
+public interface SurveyRepository extends JpaRepository<Survey, UUID> {
 
     @Override
     List<Survey> findAll();
@@ -16,5 +17,5 @@ public interface SurveyRepository extends JpaRepository<Survey, Long> {
     Survey save(Survey survey);
 
     @Override
-    Optional<Survey> findById(Long surveyId);
+    Optional<Survey> findById(UUID surveyId);
 }

--- a/api/src/main/java/com/thesurvey/api/service/SurveyService.java
+++ b/api/src/main/java/com/thesurvey/api/service/SurveyService.java
@@ -3,36 +3,41 @@ package com.thesurvey.api.service;
 import com.thesurvey.api.domain.Survey;
 import com.thesurvey.api.dto.SurveyDto;
 import com.thesurvey.api.repository.SurveyRepository;
+import com.thesurvey.api.service.mapper.SurveyMapper;
 import java.util.List;
-import java.util.Optional;
 import java.util.UUID;
+import javax.persistence.EntityNotFoundException;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 public class SurveyService {
 
     private final SurveyRepository surveyRepository;
     private final QuestionService questionService;
+    private final SurveyMapper surveyMapper;
 
-    public SurveyService(SurveyRepository surveyRepository, QuestionService questionService) {
+    public SurveyService(SurveyRepository surveyRepository, QuestionService questionService,
+        SurveyMapper surveyMapper) {
         this.surveyRepository = surveyRepository;
         this.questionService = questionService;
+        this.surveyMapper = surveyMapper;
     }
 
     public List<Survey> getAllSurvey() {
         return surveyRepository.findAll();
     }
 
-    public Optional<Survey> getSurveyById(UUID surveyId) {
-        Optional<Survey> targetSurvey = surveyRepository.findById(surveyId);
-        return Optional.of(targetSurvey.get());
+    public SurveyDto getSurveyById(UUID surveyId) {
+        return surveyMapper.toSurveyDto(surveyRepository.findById(surveyId))
+            .orElseThrow(() -> new EntityNotFoundException("Survey not found"));
     }
 
+    @Transactional
     public Survey createSurvey(Survey survey) {
         Survey newSurvey = surveyRepository.save(survey);
         questionService.addQuestion(newSurvey.getQuestions());
         return newSurvey;
     }
-
 
 }

--- a/api/src/main/java/com/thesurvey/api/service/SurveyService.java
+++ b/api/src/main/java/com/thesurvey/api/service/SurveyService.java
@@ -5,6 +5,7 @@ import com.thesurvey.api.dto.SurveyDto;
 import com.thesurvey.api.repository.SurveyRepository;
 import java.util.List;
 import java.util.Optional;
+import java.util.UUID;
 import org.springframework.stereotype.Service;
 
 @Service
@@ -22,7 +23,7 @@ public class SurveyService {
         return surveyRepository.findAll();
     }
 
-    public Optional<Survey> getSurveyById(long surveyId) {
+    public Optional<Survey> getSurveyById(UUID surveyId) {
         Optional<Survey> targetSurvey = surveyRepository.findById(surveyId);
         return Optional.of(targetSurvey.get());
     }

--- a/api/src/main/java/com/thesurvey/api/service/UserService.java
+++ b/api/src/main/java/com/thesurvey/api/service/UserService.java
@@ -2,44 +2,49 @@ package com.thesurvey.api.service;
 
 import com.thesurvey.api.domain.User;
 import com.thesurvey.api.dto.UserDto;
+import com.thesurvey.api.dto.UserInfoDto;
 import com.thesurvey.api.repository.UserRepository;
+import com.thesurvey.api.service.mapper.UserMapper;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 public class UserService {
 
     private final UserRepository userRepository;
 
-    public UserService(UserRepository userRepository) {
+    private final UserMapper userMapper;
+
+    public UserService(UserRepository userRepository, UserMapper userMapper) {
         this.userRepository = userRepository;
+        this.userMapper = userMapper;
     }
 
-    public UserDto getUserByName(String name) {
-        Optional<User> targetUser = userRepository.findByName(name);
-        UserDto targetUserDto = UserDto.builder().name(targetUser.get().getName()).build();
-        return targetUserDto;
+    public UserInfoDto getUserByName(String name) {
+        // FIXME: exception handling
+        return userMapper.toUserInfoDto(userRepository.findByName(name))
+            .orElseThrow(() -> new UsernameNotFoundException("User not found"));
     }
 
-    public UserDto getUserByEmail(String email) {
-        Optional<User> targetUser = userRepository.findByEmail(email);
-        UserDto targetUserDto = new UserDto(targetUser.get());
-        return targetUserDto;
+    public UserInfoDto getUserByEmail(String email) {
+        // FIXME: exception handling
+        return userMapper.toUserInfoDto(userRepository.findByEmail(email))
+            .orElseThrow(() -> new UsernameNotFoundException("User not found"));
     }
 
-    public User join(UserDto userDto) {
-        User newUser = userDto.toEntity();
-        return userRepository.save(newUser);
-    }
-
+    @Transactional
     public List<UserDto> getAllUsersWithAnsweredQuestion() {
         List<User> allUsersList = userRepository.findAll();
+
+        // FIXME: ArrayList to stream or something else
         List<UserDto> userDtoList = new ArrayList<>();
         for (User user : allUsersList) {
-            userDtoList.add(
-                new UserDto().builder().name(user.getName()).email(user.getEmail()).build());
+            UserDto userDto = userMapper.toUserDto(user);
+            userDtoList.add(userDto);
         }
         return userDtoList;
     }

--- a/api/src/main/java/com/thesurvey/api/service/mapper/SurveyMapper.java
+++ b/api/src/main/java/com/thesurvey/api/service/mapper/SurveyMapper.java
@@ -12,10 +12,10 @@ public class SurveyMapper {
     public Optional<SurveyDto> toSurveyDto(Optional<Survey> survey) {
         return survey
             .map(value -> SurveyDto.builder()
-                .surveyId(value.getSurveyId())
-                .title(value.getTitle())
-                .description(value.getDescription())
-                .build());
+            .surveyId(value.getSurveyId())
+            .title(value.getTitle())
+            .description(value.getDescription())
+            .build());
     }
 
     public Survey toSurvey(SurveyDto surveyDto) {

--- a/api/src/main/java/com/thesurvey/api/service/mapper/SurveyMapper.java
+++ b/api/src/main/java/com/thesurvey/api/service/mapper/SurveyMapper.java
@@ -1,0 +1,30 @@
+package com.thesurvey.api.service.mapper;
+
+import com.thesurvey.api.domain.Survey;
+import com.thesurvey.api.dto.SurveyDto;
+import java.util.Optional;
+import org.springframework.stereotype.Component;
+
+// @formatter:off
+@Component
+public class SurveyMapper {
+
+    public Optional<SurveyDto> toSurveyDto(Optional<Survey> survey) {
+        return survey
+            .map(value -> SurveyDto.builder()
+                .surveyId(value.getSurveyId())
+                .title(value.getTitle())
+                .description(value.getDescription())
+                .build());
+    }
+
+    public Survey toSurvey(SurveyDto surveyDto) {
+        return Survey
+            .builder()
+            .title(surveyDto.getTitle())
+            .description(surveyDto.getDescription())
+            .questions(surveyDto.getQuestions())
+            .build();
+    }
+}
+// @formatter:on

--- a/api/src/main/java/com/thesurvey/api/service/mapper/UserMapper.java
+++ b/api/src/main/java/com/thesurvey/api/service/mapper/UserMapper.java
@@ -1,0 +1,44 @@
+package com.thesurvey.api.service.mapper;
+
+import com.thesurvey.api.domain.User;
+import com.thesurvey.api.dto.UserDto;
+import com.thesurvey.api.dto.UserInfoDto;
+import java.util.Optional;
+import org.springframework.data.crossstore.ChangeSetPersister.NotFoundException;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.stereotype.Component;
+
+// @formatter:off
+@Component
+public class UserMapper {
+
+    public User toUser(UserDto userDto) {
+        return User
+            .builder()
+            .name(userDto.getName())
+            .email(userDto.getEmail())
+            .password(userDto.getPassword())
+            .role(userDto.getRole())
+            .build();
+    }
+
+    public UserDto toUserDto(User user) {
+        return UserDto
+            .builder()
+            .name(user.getName())
+            .email(user.getEmail())
+            .role(user.getRole())
+            .build();
+    }
+
+    public Optional<UserInfoDto> toUserInfoDto(Optional<User> user) {
+        return user.map(value -> UserInfoDto.builder()
+                .userId(value.getUserId())
+                .name(value.getName())
+                .email(value.getEmail())
+                .build());
+    }
+
+
+}
+// @formatter:on

--- a/api/src/main/resources/application-dev.yml
+++ b/api/src/main/resources/application-dev.yml
@@ -12,7 +12,7 @@ spring:
     password: the_survey_dev
   jpa:
     hibernate:
-      ddl-auto: create
+      ddl-auto: create-drop
     properties:
       hibernate:
         show_sql: true


### PR DESCRIPTION
Revised user and survey domains and resolved conflicts.

**Added**
- `LocalDateTimeEntity` to both `User` and `Survey`
- Roles for `USER` and `ADMIN`
- `@Transactional` annotation for db CUD

**Modified**
- Modified `survey_id` type (`Long` -> `UUID`)
- Builder to Entity or DTO as mapper for `User` and `Survey`