### PR TITLE
refactor: modified domains for JPA query tuning

### DIFF
--- a/api/src/main/java/com/thesurvey/api/domain/AnsweredQuestion.java
+++ b/api/src/main/java/com/thesurvey/api/domain/AnsweredQuestion.java
@@ -2,7 +2,9 @@ package com.thesurvey.api.domain;
 
 import java.util.List;
 import javax.persistence.Column;
+import javax.persistence.EmbeddedId;
 import javax.persistence.Entity;
+import javax.persistence.FetchType;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
@@ -20,24 +22,46 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class AnsweredQuestion {
 
-    @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @EmbeddedId
     @Column(name = "answered_question_id")
-    private Long answeredQuestionId;
-    @ManyToOne
-    @JoinColumn(name = "user_id")
-    private User user;
-    @ManyToOne
-    @JoinColumn(name = "question_id")
-    private Question question;
-    @ManyToOne
-    @JoinColumn(name = "survey_id")
-    private Survey survey;
+    private AnsweredQuestionId answeredQuestionId;
+
+    @Column(name = "single_choice", nullable = true)
+    private Integer singleChoice;
+
+    // FIXME: modify to join columns
+    @Column(name = "multiple_choice", nullable = true)
+    private Integer multipleChoice;
+
     @Column(name = "short_answer", nullable = true)
     private String shortAnswer;
 
+    @Column(name = "long_answer", nullable = true)
+    private String longAnswer;
+
+    @Column(name = "type", nullable = false)
+    private String type;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "question_bank_id")
+    private QuestionBank questionBank;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id")
+    private User user;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "question_id")
+    private Question question;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "survey_id")
+    private Survey survey;
+
     @Builder
-    public AnsweredQuestion(Long answeredQuestionId, User user, Survey survey, Question question, String shortAnswer) {
+    public AnsweredQuestion(AnsweredQuestionId answeredQuestionId, User user, Survey survey,
+        Question question,
+        String shortAnswer) {
         this.answeredQuestionId = answeredQuestionId;
         this.user = user;
         this.survey = survey;

--- a/api/src/main/java/com/thesurvey/api/domain/AnsweredQuestionId.java
+++ b/api/src/main/java/com/thesurvey/api/domain/AnsweredQuestionId.java
@@ -1,0 +1,21 @@
+package com.thesurvey.api.domain;
+
+import java.io.Serializable;
+import java.util.UUID;
+import javax.persistence.Column;
+import javax.persistence.Embeddable;
+import lombok.Getter;
+
+@Embeddable
+@Getter
+public class AnsweredQuestionId implements Serializable {
+
+    @Column(name = "survey_id")
+    private UUID surveyId;
+
+    @Column(name = "question_bank_id")
+    private Long questionBankId;
+
+    @Column(name = "user_id")
+    private Long userId;
+}

--- a/api/src/main/java/com/thesurvey/api/domain/BaseTimeEntity.java
+++ b/api/src/main/java/com/thesurvey/api/domain/BaseTimeEntity.java
@@ -15,7 +15,7 @@ import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 public abstract class BaseTimeEntity {
 
     @CreatedDate
-    @Column(name = "created_date", nullable = false)
+    @Column(name = "created_date")
     private LocalDateTime createdDate;
 
     @LastModifiedDate

--- a/api/src/main/java/com/thesurvey/api/domain/Participation.java
+++ b/api/src/main/java/com/thesurvey/api/domain/Participation.java
@@ -1,16 +1,11 @@
 package com.thesurvey.api.domain;
 
-import java.sql.Timestamp;
+import java.time.LocalDateTime;
 import javax.persistence.Column;
+import javax.persistence.EmbeddedId;
 import javax.persistence.Entity;
-import javax.persistence.GeneratedValue;
-import javax.persistence.GenerationType;
-import javax.persistence.Id;
-import javax.persistence.JoinColumn;
-import javax.persistence.ManyToOne;
 import javax.persistence.Table;
 import lombok.AccessLevel;
-import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -20,24 +15,17 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Participation {
 
-    @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @EmbeddedId
     @Column(name = "participation_id")
-    private Long participationId;
-    @Column(name = "participate_date", nullable = false)
-    private Timestamp participateDate;
-    @ManyToOne
-    @JoinColumn(name = "survey_id")
-    private Survey survey;
-    @ManyToOne
-    @JoinColumn(name = "user_id")
-    private User user;
+    private ParticipationId participationId;
 
-    @Builder
-    public Participation(Long participationId, Timestamp participateDate, Survey survey, User user) {
-        this.participationId = participationId;
-        this.participateDate = participateDate;
-        this.survey = survey;
-        this.user = user;
-    }
+    @Column(name = "participate_date", nullable = false)
+    private LocalDateTime participateDate;
+
+    @Column(name = "submitted_date", nullable = false)
+    private LocalDateTime submittedDate;
+
+    @Column(name = "certification_type", nullable = false)
+    private String certificationType;
+
 }

--- a/api/src/main/java/com/thesurvey/api/domain/ParticipationId.java
+++ b/api/src/main/java/com/thesurvey/api/domain/ParticipationId.java
@@ -1,0 +1,18 @@
+package com.thesurvey.api.domain;
+
+import java.io.Serializable;
+import java.util.UUID;
+import javax.persistence.Column;
+import javax.persistence.Embeddable;
+import lombok.Getter;
+
+@Embeddable
+@Getter
+public class ParticipationId implements Serializable {
+
+    @Column(name = "survey_id")
+    private UUID surveyId;
+
+    @Column(name = "user_id")
+    private Long userId;
+}

--- a/api/src/main/java/com/thesurvey/api/domain/Question.java
+++ b/api/src/main/java/com/thesurvey/api/domain/Question.java
@@ -1,10 +1,9 @@
 package com.thesurvey.api.domain;
 
 import javax.persistence.Column;
+import javax.persistence.EmbeddedId;
 import javax.persistence.Entity;
-import javax.persistence.GeneratedValue;
-import javax.persistence.GenerationType;
-import javax.persistence.Id;
+import javax.persistence.FetchType;
 import javax.persistence.JoinColumn;
 import javax.persistence.ManyToOne;
 import javax.persistence.Table;
@@ -19,19 +18,23 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Question {
 
-    @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @EmbeddedId
     @Column(name = "question_id")
-    private Long questionId;
+    private QuestionId questionId;
+
     @Column(name = "description", nullable = true)
     private String description;
 
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "survey_id")
     private Survey survey;
 
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "question_bank_id", insertable = false, updatable = false)
+    private QuestionBank questionBank;
+
     @Builder
-    public Question(Long questionId, String description, Survey survey) {
+    public Question(QuestionId questionId, String description, Survey survey) {
         this.questionId = questionId;
         this.description = description;
         this.survey = survey;

--- a/api/src/main/java/com/thesurvey/api/domain/QuestionBank.java
+++ b/api/src/main/java/com/thesurvey/api/domain/QuestionBank.java
@@ -1,0 +1,33 @@
+package com.thesurvey.api.domain;
+
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.Id;
+import javax.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@Table(name = "question_bank")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class QuestionBank {
+
+    @Id
+    @Column(name = "question_bank_id")
+    private Long questionBankId;
+
+    @Column(name = "title")
+    private String title;
+
+    @Column(name = "description")
+    private String description;
+
+    @Column(name = "question", nullable = false)
+    private String question;
+
+    @Column(name = "type", nullable = false)
+    private String type;
+
+}

--- a/api/src/main/java/com/thesurvey/api/domain/QuestionId.java
+++ b/api/src/main/java/com/thesurvey/api/domain/QuestionId.java
@@ -1,0 +1,18 @@
+package com.thesurvey.api.domain;
+
+import java.io.Serializable;
+import java.util.UUID;
+import javax.persistence.Column;
+import javax.persistence.Embeddable;
+import lombok.Getter;
+
+@Embeddable
+@Getter
+public class QuestionId implements Serializable {
+
+    @Column(name = "survey_id")
+    private UUID surveyId;
+
+    @Column(name = "question_bank_id")
+    private Long questionBankId;
+}

--- a/api/src/main/java/com/thesurvey/api/domain/Survey.java
+++ b/api/src/main/java/com/thesurvey/api/domain/Survey.java
@@ -1,16 +1,11 @@
 package com.thesurvey.api.domain;
 
-import com.fasterxml.jackson.annotation.JsonManagedReference;
-import java.util.ArrayList;
-import java.util.List;
 import java.util.UUID;
 import javax.persistence.Column;
 import javax.persistence.Entity;
-import javax.persistence.FetchType;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
-import javax.persistence.OneToMany;
 import javax.persistence.Table;
 import lombok.AccessLevel;
 import lombok.Builder;
@@ -24,29 +19,19 @@ import lombok.NoArgsConstructor;
 public class Survey extends BaseTimeEntity {
 
     @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "survey_id")
     private UUID surveyId;
+
     @Column(name = "title", nullable = false)
     private String title;
 
     @Column(name = "description", nullable = false)
     private String description;
 
-    @OneToMany(mappedBy = "survey", fetch = FetchType.EAGER)
-    @JsonManagedReference
-    private List<Question> questions;
-
-    @OneToMany(mappedBy = "survey", fetch = FetchType.LAZY)
-    private List<Participation> participations = new ArrayList<>();
-
     @Builder
-    public Survey(String title, String description, List<Question> questions,
-        List<Participation> participations) {
+    public Survey(String title, String description) {
         this.title = title;
         this.description = description;
-        this.questions = questions;
-        this.participations = participations;
     }
 
 }

--- a/api/src/main/java/com/thesurvey/api/domain/User.java
+++ b/api/src/main/java/com/thesurvey/api/domain/User.java
@@ -1,17 +1,14 @@
 package com.thesurvey.api.domain;
 
-import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.EnumType;
 import javax.persistence.Enumerated;
-import javax.persistence.FetchType;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
-import javax.persistence.OneToMany;
 import javax.persistence.Table;
 import lombok.AccessLevel;
 import lombok.Builder;
@@ -32,28 +29,31 @@ public class User extends BaseTimeEntity implements UserDetails {
     @Column(name = "user_id")
     private Long userId;
 
+    @Column(name = "name", nullable = false)
+    private String name;
+
     @Column(name = "email", nullable = false)
     private String email;
 
     @Column(name = "password", nullable = false)
     private String password;
 
-    @Column(name = "name", nullable = false)
-    private String name;
-    @OneToMany(mappedBy = "user", fetch = FetchType.LAZY)
-    private List<Participation> participations = new ArrayList<>();
-    @OneToMany(mappedBy = "user")
-    private List<AnsweredQuestion> answeredQuestions = new ArrayList<>();
+    @Column(name = "phone_number", nullable = false)
+    private String phoneNumber;
 
+    @Column(name = "address", nullable = true)
+    private String address;
+
+    @Column(name = "profile_image", nullable = true)
+    private String profileImage;
 
     @Builder
-    public User(String email, String name, Role role, String password,
-        List<AnsweredQuestion> answeredQuestions) {
+    public User(String email, String name, Role role, String password, String phoneNumber) {
         this.email = email;
         this.name = name;
         this.role = role;
         this.password = password;
-        this.answeredQuestions = answeredQuestions;
+        this.phoneNumber = phoneNumber;
     }
 
     @Enumerated(EnumType.STRING)
@@ -93,4 +93,5 @@ public class User extends BaseTimeEntity implements UserDetails {
     public boolean isEnabled() {
         return true;
     }
+
 }


### PR DESCRIPTION
**Modified**
- Unmapped bidirectional relation mapping for `User` and `Survey` domains.
- Refactored codebase for composite primary keys (Separate `@Id`s are indexed respectively so low performance. Also check #44)

Resolves #44.