### PR TITLE
fix: test for survey validation

### DIFF
--- a/api/src/main/java/com/thesurvey/api/dto/request/QuestionBankUpdateRequestDto.java
+++ b/api/src/main/java/com/thesurvey/api/dto/request/QuestionBankUpdateRequestDto.java
@@ -3,7 +3,6 @@ package com.thesurvey.api.dto.request;
 import com.thesurvey.api.domain.EnumTypeEntity.QuestionType;
 import java.util.List;
 import javax.validation.Valid;
-import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.NotNull;
 import javax.validation.constraints.Positive;
 import javax.validation.constraints.Size;
@@ -18,21 +17,17 @@ public class QuestionBankUpdateRequestDto {
     @Positive
     private Long questionBankId;
 
-    @NotBlank
     @Size(max = 100)
     private String title;
 
-    @NotBlank
     @Size(max = 255)
     private String description;
 
-    @NotNull
+    @Valid
     private QuestionType questionType;
 
-    @NotNull
     private Boolean isRequired;
 
-    @NotNull
     @Positive
     private Integer questionNo;
 

--- a/api/src/main/java/com/thesurvey/api/dto/request/QuestionOptionRequestDto.java
+++ b/api/src/main/java/com/thesurvey/api/dto/request/QuestionOptionRequestDto.java
@@ -9,11 +9,11 @@ import lombok.Getter;
 @Builder
 public class QuestionOptionRequestDto {
 
-        @NotBlank
-        @Size(max = 100)
-        private String option;
+    @NotBlank
+    @Size(max = 100)
+    private String option;
 
-        @Size(max = 255)
-        private String description;
+    @Size(max = 255)
+    private String description;
 
 }

--- a/api/src/main/java/com/thesurvey/api/dto/request/QuestionOptionUpdateRequestDto.java
+++ b/api/src/main/java/com/thesurvey/api/dto/request/QuestionOptionUpdateRequestDto.java
@@ -1,6 +1,5 @@
 package com.thesurvey.api.dto.request;
 
-import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.NotNull;
 import javax.validation.constraints.Positive;
 import javax.validation.constraints.Size;
@@ -15,7 +14,6 @@ public class QuestionOptionUpdateRequestDto {
     @Positive
     private Long optionId;
 
-    @NotBlank
     @Size(max = 50)
     private String option;
 

--- a/api/src/main/java/com/thesurvey/api/dto/request/SurveyRequestDto.java
+++ b/api/src/main/java/com/thesurvey/api/dto/request/SurveyRequestDto.java
@@ -36,10 +36,10 @@ public class SurveyRequestDto {
     @ApiModelProperty(name = "설문조사 종료일", example = "2023-04-08T00:00:00")
     private LocalDateTime endedDate;
 
+    @Valid
     private List<CertificationType> certificationType;
 
     @Valid
-    @NotNull
     @NotEmpty
     private List<QuestionRequestDto> questions;
 

--- a/api/src/main/java/com/thesurvey/api/dto/request/SurveyUpdateRequestDto.java
+++ b/api/src/main/java/com/thesurvey/api/dto/request/SurveyUpdateRequestDto.java
@@ -6,7 +6,6 @@ import java.util.List;
 import java.util.UUID;
 import javax.validation.Valid;
 import javax.validation.constraints.Future;
-import javax.validation.constraints.NotEmpty;
 import javax.validation.constraints.NotNull;
 import javax.validation.constraints.Size;
 import lombok.Builder;
@@ -34,7 +33,6 @@ public class SurveyUpdateRequestDto {
     private List<CertificationType> certificationType;
 
     @Valid
-    @NotEmpty
     private List<QuestionBankUpdateRequestDto> questions;
 
 }

--- a/api/src/main/java/com/thesurvey/api/dto/request/SurveyUpdateRequestDto.java
+++ b/api/src/main/java/com/thesurvey/api/dto/request/SurveyUpdateRequestDto.java
@@ -6,7 +6,6 @@ import java.util.List;
 import java.util.UUID;
 import javax.validation.Valid;
 import javax.validation.constraints.Future;
-import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.NotEmpty;
 import javax.validation.constraints.NotNull;
 import javax.validation.constraints.Size;
@@ -20,25 +19,21 @@ public class SurveyUpdateRequestDto {
     @NotNull
     private UUID surveyId;
 
-    @NotBlank
     @Size(max = 100)
     private String title;
 
-    @NotBlank
     @Size(max = 255)
     private String description;
 
-    @NotNull
     private LocalDateTime startedDate;
 
-    @NotNull
     @Future
     private LocalDateTime endedDate;
 
+    @Valid
     private List<CertificationType> certificationType;
 
     @Valid
-    @NotNull
     @NotEmpty
     private List<QuestionBankUpdateRequestDto> questions;
 

--- a/api/src/main/java/com/thesurvey/api/dto/request/UserUpdateRequestDto.java
+++ b/api/src/main/java/com/thesurvey/api/dto/request/UserUpdateRequestDto.java
@@ -1,7 +1,6 @@
 package com.thesurvey.api.dto.request;
 
 import io.swagger.annotations.ApiModelProperty;
-import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.Pattern;
 import javax.validation.constraints.Size;
 import lombok.AllArgsConstructor;
@@ -15,12 +14,10 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 public class UserUpdateRequestDto {
 
-    @NotBlank
     @Pattern(regexp = "^(?=.*\\d)(?=.*[a-z])(?=.*[A-Z])(?=.*[~!@#$%^&*()_+=])\\S{8,25}$")
     @ApiModelProperty(name = "비밀번호", example = "Mypassword123@")
     private String password;
 
-    @NotBlank
     @Pattern(regexp = "^01[016-9]\\d{7,8}$")
     @ApiModelProperty(name = "휴대폰 번호", example = "01012345678")
     private String phoneNumber;

--- a/api/src/main/java/com/thesurvey/api/service/QuestionService.java
+++ b/api/src/main/java/com/thesurvey/api/service/QuestionService.java
@@ -54,7 +54,7 @@ public class QuestionService {
                 questionBankMapper.toQuestionBank(questionRequestDto));
             questionRepository.save(
                 questionMapper.toQuestion(questionRequestDto, survey, questionBank));
-            if(questionRequestDto.getQuestionOptions() != null) {
+            if (questionRequestDto.getQuestionOptions() != null) {
                 questionOptionService.createQuestionOption(questionRequestDto, questionBank);
             }
         }

--- a/api/src/main/java/com/thesurvey/api/service/SurveyService.java
+++ b/api/src/main/java/com/thesurvey/api/service/SurveyService.java
@@ -29,7 +29,8 @@ public class SurveyService {
 
     public SurveyService(SurveyRepository surveyRepository, SurveyMapper surveyMapper,
         QuestionService questionService,
-        ParticipationService participationService, AnsweredQuestionService answeredQuestionService) {
+        ParticipationService participationService,
+        AnsweredQuestionService answeredQuestionService) {
         this.surveyRepository = surveyRepository;
         this.surveyMapper = surveyMapper;
         this.questionService = questionService;
@@ -79,7 +80,8 @@ public class SurveyService {
 
     @Transactional
     public SurveyResponseDto updateSurvey(SurveyUpdateRequestDto surveyUpdateRequestDto) {
-        validateRequestedSurveyDate(surveyUpdateRequestDto.getStartedDate(), surveyUpdateRequestDto.getEndedDate());
+        validateRequestedSurveyDate(surveyUpdateRequestDto.getStartedDate(),
+            surveyUpdateRequestDto.getEndedDate());
 
         Survey survey = surveyRepository.findBySurveyId(surveyUpdateRequestDto.getSurveyId())
             .orElseThrow(

--- a/api/src/main/java/com/thesurvey/api/service/converter/CertificationTypeConverter.java
+++ b/api/src/main/java/com/thesurvey/api/service/converter/CertificationTypeConverter.java
@@ -1,43 +1,39 @@
 package com.thesurvey.api.service.converter;
 
 import com.thesurvey.api.domain.EnumTypeEntity.CertificationType;
-import java.util.ArrayList;
 import java.util.List;
+import java.util.stream.Collectors;
 import org.springframework.context.annotation.Configuration;
 
 @Configuration
 public class CertificationTypeConverter {
 
     /**
-     * return List<Integer> certificationTypeList to
-     * List<CertificationType> convertedCertificationTypeList.
+     * Converts certificationTypeList type from Integer to CertificationType.
+     *
      * @param certificationTypeList List converted from CertificationType to Integer in db.
      * @return convertedCertificationTypeList List converted from Integer to CertificationType.
      */
     public List<CertificationType> toCertificationTypeList(List<Integer> certificationTypeList) {
-        List<CertificationType> convertedCertificationTypeList = new ArrayList<>();
-        for (Integer type : certificationTypeList) {
-
-            if (type == 0) {
-                convertedCertificationTypeList.add(CertificationType.KAKAO);
-            }
-            else if (type == 1) {
-                convertedCertificationTypeList.add(CertificationType.NAVER);
-            }
-            else if (type == 2) {
-                convertedCertificationTypeList.add(CertificationType.GOOGLE);
-            }
-            else if (type == 3) {
-                convertedCertificationTypeList.add(CertificationType.WEBMAIL);
-            }
-            else if (type == 4) {
-                convertedCertificationTypeList.add(CertificationType.DRIVER_LICENSE);
-            }
-            else if (type == 5) {
-                convertedCertificationTypeList.add(CertificationType.MOBILE_PHONE);
-            }
-
-        }
-        return convertedCertificationTypeList;
+        return certificationTypeList.stream()
+            .map(type -> {
+                switch (type) {
+                    case 0:
+                        return CertificationType.KAKAO;
+                    case 1:
+                        return CertificationType.NAVER;
+                    case 2:
+                        return CertificationType.GOOGLE;
+                    case 3:
+                        return CertificationType.WEBMAIL;
+                    case 4:
+                        return CertificationType.DRIVER_LICENSE;
+                    case 5:
+                        return CertificationType.MOBILE_PHONE;
+                    default:
+                        return null;
+                }
+            })
+            .collect(Collectors.toList());
     }
 }

--- a/api/src/test/java/com/thesurvey/api/controller/SurveyControllerTest.java
+++ b/api/src/test/java/com/thesurvey/api/controller/SurveyControllerTest.java
@@ -42,7 +42,7 @@ import org.springframework.transaction.annotation.Transactional;
 @Transactional
 @TestInstance(Lifecycle.PER_CLASS)
 @AutoConfigureMockMvc
-public class SurveyControllerIntegrateTest extends BaseControllerTest {
+public class SurveyControllerTest extends BaseControllerTest {
 
     @Autowired
     SurveyRepository surveyRepository;

--- a/api/src/test/java/com/thesurvey/api/controller/SurveyControllerTest.java
+++ b/api/src/test/java/com/thesurvey/api/controller/SurveyControllerTest.java
@@ -83,8 +83,6 @@ public class SurveyControllerTest extends BaseControllerTest {
     @Autowired
     AuthenticationManager authenticationManager;
 
-    SurveyTestFactory surveyTestFactory;
-
     @BeforeEach
     void makeMockUser() throws Exception {
         mockRegister(globalRegisterDto, true);
@@ -104,7 +102,7 @@ public class SurveyControllerTest extends BaseControllerTest {
             globalLoginDto.getEmail(), globalLoginDto.getPassword());
         Authentication authentication = authenticationManager.authenticate(authRequest);
         SecurityContextHolder.getContext().setAuthentication(authentication);
-        SurveyRequestDto testSurveyRequestDto = surveyTestFactory.getGlobalSurveyRequestDto();
+        SurveyRequestDto testSurveyRequestDto = SurveyTestFactory.getGlobalSurveyRequestDto();
 
         // when
         ResultActions resultActions = mockMvc.perform(MockMvcRequestBuilders.post("/surveys")
@@ -128,10 +126,10 @@ public class SurveyControllerTest extends BaseControllerTest {
 //            globalLoginDto.getEmail(), globalLoginDto.getPassword());
 //        Authentication authentication = authenticationManager.authenticate(authRequest);
 //        SecurityContextHolder.getContext().setAuthentication(authentication);
-//        SurveyRequestDto testSurveyRequestDto = surveyTestFactory.getGlobalSurveyRequestDto();
+//        SurveyRequestDto testSurveyRequestDto = SurveyTestFactory.getGlobalSurveyRequestDto();
 //        SurveyResponseDto testSurveyResponseDto = surveyService.createSurvey(authentication,
 //            testSurveyRequestDto);
-//        SurveyUpdateRequestDto testSurveyUpdateRequestDto = surveyTestFactory.getSurveyUpdateRequestDto(
+//        SurveyUpdateRequestDto testSurveyUpdateRequestDto = SurveyTestFactory.getSurveyUpdateRequestDto(
 //            testSurveyResponseDto.getSurveyId());
 //
 //        ResultActions resultActions = mockMvc.perform(MockMvcRequestBuilders.put("/surveys")
@@ -149,7 +147,7 @@ public class SurveyControllerTest extends BaseControllerTest {
         Authentication authentication = authenticationManager.authenticate(authRequest);
         SecurityContextHolder.getContext().setAuthentication(authentication);
 
-        SurveyRequestDto testSurveyRequestDto = surveyTestFactory.getGlobalSurveyRequestDto();
+        SurveyRequestDto testSurveyRequestDto = SurveyTestFactory.getGlobalSurveyRequestDto();
         MvcResult mvcResult = mockCreateSurvey(testSurveyRequestDto);
         JSONObject content = new JSONObject(mvcResult.getResponse().getContentAsString());
         String testSurveyId = content.get("surveyId").toString();
@@ -171,7 +169,7 @@ public class SurveyControllerTest extends BaseControllerTest {
         Authentication authentication = authenticationManager.authenticate(authRequest);
         SecurityContextHolder.getContext().setAuthentication(authentication);
 
-        SurveyRequestDto testSurveyRequestDto = surveyTestFactory.getGlobalSurveyRequestDto();
+        SurveyRequestDto testSurveyRequestDto = SurveyTestFactory.getGlobalSurveyRequestDto();
         MvcResult createSurveyResult = mockCreateSurvey(testSurveyRequestDto);
         JSONObject content = new JSONObject(createSurveyResult.getResponse().getContentAsString());
         String testSurveyId = content.get("surveyId").toString();
@@ -198,11 +196,11 @@ public class SurveyControllerTest extends BaseControllerTest {
         Authentication authentication = authenticationManager.authenticate(authRequest);
         SecurityContextHolder.getContext().setAuthentication(authentication);
 
-        SurveyRequestDto testSurveyRequestDto = surveyTestFactory.getGlobalSurveyRequestDto();
+        SurveyRequestDto testSurveyRequestDto = SurveyTestFactory.getGlobalSurveyRequestDto();
         MvcResult createSurveyResult = mockCreateSurvey(testSurveyRequestDto);
         JSONObject content = new JSONObject(createSurveyResult.getResponse().getContentAsString());
         String testSurveyId = content.get("surveyId").toString();
-        AnsweredQuestionRequestDto testAnsweredQuestionRequestDto = surveyTestFactory.getAnsweredQuestionRequestDto(
+        AnsweredQuestionRequestDto testAnsweredQuestionRequestDto = SurveyTestFactory.getAnsweredQuestionRequestDto(
             UUID.fromString(testSurveyId));
 
         // when

--- a/api/src/test/java/com/thesurvey/api/dto/AnsweredQuestionDtoValidTest.java
+++ b/api/src/test/java/com/thesurvey/api/dto/AnsweredQuestionDtoValidTest.java
@@ -40,7 +40,7 @@ public class AnsweredQuestionDtoValidTest implements CommonTestMethod {
 
     @Override
     @Test
-    public void testValidateNullInput() {
+    public void testValidateNotNull() {
         // given
         AnsweredQuestionDto answeredQuestionDto = AnsweredQuestionDto.builder()
             .questionTitle(null)
@@ -58,13 +58,14 @@ public class AnsweredQuestionDtoValidTest implements CommonTestMethod {
     @Override
     @Test
     public void testValidateOverMaxStringLength() {
+        // given
         StringBuilder maxLengthStringBuilder = new StringBuilder();
         while (maxLengthStringBuilder.length() < 256) {
             maxLengthStringBuilder.append("Test String.....");
         }
+
         String maxLengthString = maxLengthStringBuilder.toString();
 
-        // given
         AnsweredQuestionDto answeredQuestionDto = AnsweredQuestionDto.builder()
             .questionTitle(maxLengthString)
             .questionDescription(maxLengthString)
@@ -86,8 +87,8 @@ public class AnsweredQuestionDtoValidTest implements CommonTestMethod {
     public void testValidateNotBlank() {
         // given
         AnsweredQuestionDto answeredQuestionDto = AnsweredQuestionDto.builder()
-            .questionTitle("")
-            .questionDescription("")
+            .questionTitle(" ") // violated by @NotBlank
+            .questionDescription(" ") // violated by @NotBlank
             .build();
 
         // when
@@ -95,6 +96,24 @@ public class AnsweredQuestionDtoValidTest implements CommonTestMethod {
             answeredQuestionDto);
 
         // then
-        assertEquals(validateSet.size(), 2);
+        assertEquals(validateSet.size(), 2); // violated total 2 constraints
     }
+
+    @Override
+    @Test
+    public void testValidateNotEmpty() {
+        // given
+        AnsweredQuestionDto answeredQuestionDto = AnsweredQuestionDto.builder()
+            .questionTitle("") // violated by @NotBlank
+            .questionDescription("") // violated by @NotBlank
+            .build();
+
+        // when
+        Set<ConstraintViolation<AnsweredQuestionDto>> validateSet = validator.validate(
+            answeredQuestionDto);
+
+        // then
+        assertEquals(validateSet.size(), 2); // violated total 2 constraints
+    }
+
 }

--- a/api/src/test/java/com/thesurvey/api/dto/AnsweredQuestionRequestDtoValidTest.java
+++ b/api/src/test/java/com/thesurvey/api/dto/AnsweredQuestionRequestDtoValidTest.java
@@ -48,7 +48,7 @@ public class AnsweredQuestionRequestDtoValidTest {
     }
 
     @Test
-    public void testValidateNullInput() {
+    public void testValidateNotNull() {
         // given
         AnsweredQuestionRequestDto answeredQuestionRequestDto = AnsweredQuestionRequestDto.builder()
             .surveyId(null)

--- a/api/src/test/java/com/thesurvey/api/dto/AnsweredQuestionRequestDtoValidTest.java
+++ b/api/src/test/java/com/thesurvey/api/dto/AnsweredQuestionRequestDtoValidTest.java
@@ -18,7 +18,7 @@ import org.springframework.data.jpa.mapping.JpaMetamodelMappingContext;
 
 @WebMvcTest(value = SurveyController.class, useDefaultFilters = false)
 @MockBean(JpaMetamodelMappingContext.class)
-public class AnsweredQuestionRequestDtoValidTestValidTest {
+public class AnsweredQuestionRequestDtoValidTest {
 
     @Autowired
     private Validator validator;

--- a/api/src/test/java/com/thesurvey/api/dto/CommonTestMethod.java
+++ b/api/src/test/java/com/thesurvey/api/dto/CommonTestMethod.java
@@ -4,9 +4,12 @@ public interface CommonTestMethod {
 
     void testCorrectInput();
 
-    void testValidateNullInput();
+    void testValidateNotNull();
 
     void testValidateOverMaxStringLength();
 
     void testValidateNotBlank();
+
+    void testValidateNotEmpty();
+
 }

--- a/api/src/test/java/com/thesurvey/api/dto/QuestionBankUpdateRequestDtoValidTest.java
+++ b/api/src/test/java/com/thesurvey/api/dto/QuestionBankUpdateRequestDtoValidTest.java
@@ -18,12 +18,11 @@ import org.springframework.data.jpa.mapping.JpaMetamodelMappingContext;
 
 @WebMvcTest(value = SurveyController.class, useDefaultFilters = false)
 @MockBean(JpaMetamodelMappingContext.class)
-public class QuestionBankUpdateRequestDtoValidTest implements CommonTestMethod {
+public class QuestionBankUpdateRequestDtoValidTest {
 
     @Autowired
     private Validator validator;
 
-    @Override
     @Test
     public void testCorrectInput() {
         // given
@@ -54,17 +53,11 @@ public class QuestionBankUpdateRequestDtoValidTest implements CommonTestMethod {
         assertEquals(validateSet.size(), 0);
     }
 
-    @Override
     @Test
-    public void testValidateNullInput() {
+    public void testValidateNotNull() {
         // given
         QuestionBankUpdateRequestDto questionBankUpdateRequestDto = QuestionBankUpdateRequestDto.builder()
-            .questionBankId(null)
-            .title(null)
-            .description(null)
-            .questionType(null)
-            .questionNo(null)
-            .isRequired(null)
+            .questionBankId(null) // violated by @NotNull
             .build();
 
         // when
@@ -72,11 +65,10 @@ public class QuestionBankUpdateRequestDtoValidTest implements CommonTestMethod {
             questionBankUpdateRequestDto);
 
         // then
-        assertEquals(validateSet.size(), 6);
+        assertEquals(validateSet.size(), 1); // violated total 1 constraint
 
     }
 
-    @Override
     @Test
     public void testValidateOverMaxStringLength() {
         // given
@@ -89,30 +81,6 @@ public class QuestionBankUpdateRequestDtoValidTest implements CommonTestMethod {
             .questionBankId(1L)
             .title(maxLengthString)
             .description(maxLengthString)
-            .questionType(QuestionType.LONG_ANSWER)
-            .questionNo(1)
-            .isRequired(true)
-            .build();
-
-        // when
-        Set<ConstraintViolation<QuestionBankUpdateRequestDto>> validateSet = validator.validate(
-            questionBankUpdateRequestDto);
-
-        // then
-        assertEquals(validateSet.size(), 2);
-    }
-
-    @Override
-    @Test
-    public void testValidateNotBlank() {
-        // given
-        QuestionBankUpdateRequestDto questionBankUpdateRequestDto = QuestionBankUpdateRequestDto.builder()
-            .questionBankId(1L)
-            .title("")
-            .description("")
-            .questionType(QuestionType.LONG_ANSWER)
-            .questionNo(1)
-            .isRequired(true)
             .build();
 
         // when
@@ -128,11 +96,7 @@ public class QuestionBankUpdateRequestDtoValidTest implements CommonTestMethod {
         // given
         QuestionBankUpdateRequestDto questionBankUpdateRequestDto = QuestionBankUpdateRequestDto.builder()
             .questionBankId(-1L)
-            .title("This is test QuestionBankUpdateRequestDto")
-            .description("This is test QuestionBankUpdateRequestDto")
-            .questionType(QuestionType.LONG_ANSWER)
             .questionNo(-1)
-            .isRequired(true)
             .build();
 
         // when

--- a/api/src/test/java/com/thesurvey/api/dto/QuestionOptionRequestDtoValidTest.java
+++ b/api/src/test/java/com/thesurvey/api/dto/QuestionOptionRequestDtoValidTest.java
@@ -38,7 +38,7 @@ public class QuestionOptionRequestDtoValidTest implements CommonTestMethod {
 
     @Override
     @Test
-    public void testValidateNullInput() {
+    public void testValidateNotNull() {
         // given
         QuestionOptionRequestDto questionOptionRequestDto = QuestionOptionRequestDto.builder()
             .option(null)
@@ -79,7 +79,7 @@ public class QuestionOptionRequestDtoValidTest implements CommonTestMethod {
     public void testValidateNotBlank() {
         // given
         QuestionOptionRequestDto questionOptionRequestDto = QuestionOptionRequestDto.builder()
-            .option("")
+            .option(" ") // violated by @NotBlank
             .build();
 
         // when
@@ -87,7 +87,22 @@ public class QuestionOptionRequestDtoValidTest implements CommonTestMethod {
             questionOptionRequestDto);
 
         // then
-        assertEquals(validateSet.size(), 1);
+        assertEquals(validateSet.size(), 1); // violated total 1 constraint
     }
 
+    @Override
+    @Test
+    public void testValidateNotEmpty() {
+        // given
+        QuestionOptionRequestDto questionOptionRequestDto = QuestionOptionRequestDto.builder()
+            .option("") // violated by @NotBlank
+            .build();
+
+        // when
+        Set<ConstraintViolation<QuestionOptionRequestDto>> validateSet = validator.validate(
+            questionOptionRequestDto);
+
+        // then
+        assertEquals(validateSet.size(), 1); // violated total 1 constraint
+    }
 }

--- a/api/src/test/java/com/thesurvey/api/dto/QuestionOptionUpdateRequestDtoValidTest.java
+++ b/api/src/test/java/com/thesurvey/api/dto/QuestionOptionUpdateRequestDtoValidTest.java
@@ -14,12 +14,11 @@ import org.springframework.data.jpa.mapping.JpaMetamodelMappingContext;
 
 @WebMvcTest(value = SurveyController.class, useDefaultFilters = false)
 @MockBean(JpaMetamodelMappingContext.class)
-public class QuestionOptionUpdateRequestDtoValidTest implements CommonTestMethod {
+public class QuestionOptionUpdateRequestDtoValidTest {
 
     @Autowired
     private Validator validator;
 
-    @Override
     @Test
     public void testCorrectInput() {
         // given
@@ -37,13 +36,11 @@ public class QuestionOptionUpdateRequestDtoValidTest implements CommonTestMethod
         assertEquals(validateSet.size(), 0);
     }
 
-    @Override
     @Test
-    public void testValidateNullInput() {
+    public void testValidateNotNull() {
         // given
         QuestionOptionUpdateRequestDto questionOptionUpdateRequestDto = QuestionOptionUpdateRequestDto.builder()
             .optionId(null)
-            .option(null)
             .build();
 
         // when
@@ -51,11 +48,10 @@ public class QuestionOptionUpdateRequestDtoValidTest implements CommonTestMethod
             questionOptionUpdateRequestDto);
 
         // then
-        assertEquals(validateSet.size(), 2);
+        assertEquals(validateSet.size(), 1);
 
     }
 
-    @Override
     @Test
     public void testValidateOverMaxStringLength() {
         // given
@@ -78,20 +74,4 @@ public class QuestionOptionUpdateRequestDtoValidTest implements CommonTestMethod
         assertEquals(validateSet.size(), 2);
     }
 
-    @Override
-    @Test
-    public void testValidateNotBlank() {
-        // given
-        QuestionOptionUpdateRequestDto questionOptionUpdateRequestDto = QuestionOptionUpdateRequestDto.builder()
-            .optionId(1L)
-            .option("")
-            .build();
-
-        // when
-        Set<ConstraintViolation<QuestionOptionUpdateRequestDto>> validateSet = validator.validate(
-            questionOptionUpdateRequestDto);
-
-        // then
-        assertEquals(validateSet.size(), 1);
-    }
 }

--- a/api/src/test/java/com/thesurvey/api/dto/QuestionRequestDtoValidTest.java
+++ b/api/src/test/java/com/thesurvey/api/dto/QuestionRequestDtoValidTest.java
@@ -43,7 +43,7 @@ public class QuestionRequestDtoValidTest implements CommonTestMethod {
 
     @Override
     @Test
-    public void testValidateNullInput() {
+    public void testValidateNotNull() {
         // given
         QuestionRequestDto questionRequestDto = QuestionRequestDto.builder()
             .title(null)
@@ -90,8 +90,8 @@ public class QuestionRequestDtoValidTest implements CommonTestMethod {
     @Test
     public void testValidateNotBlank() {
         QuestionRequestDto questionRequestDto = QuestionRequestDto.builder()
-            .title("")
-            .description("")
+            .title(" ") // violated by @NotBlank
+            .description(" ") // violated by @NotBlank
             .questionType(QuestionType.LONG_ANSWER)
             .questionNo(1)
             .isRequired(true)
@@ -102,6 +102,25 @@ public class QuestionRequestDtoValidTest implements CommonTestMethod {
             questionRequestDto);
 
         // then
-        assertEquals(validateSet.size(), 2);
+        assertEquals(validateSet.size(), 2); // violated total 2 constraints
+    }
+
+    @Override
+    @Test
+    public void testValidateNotEmpty() {
+        QuestionRequestDto questionRequestDto = QuestionRequestDto.builder()
+            .title("") // violated by @NotBlank
+            .description("") // violated by @NotBlank
+            .questionType(QuestionType.LONG_ANSWER)
+            .questionNo(1)
+            .isRequired(true)
+            .build();
+
+        // when
+        Set<ConstraintViolation<QuestionRequestDto>> validateSet = validator.validate(
+            questionRequestDto);
+
+        // then
+        assertEquals(validateSet.size(), 2); // violated total 2 constraints
     }
 }

--- a/api/src/test/java/com/thesurvey/api/dto/SurveyRequestDtoValidTest.java
+++ b/api/src/test/java/com/thesurvey/api/dto/SurveyRequestDtoValidTest.java
@@ -8,7 +8,6 @@ import com.thesurvey.api.dto.request.SurveyRequestDto;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.List;
 import java.util.Set;
 import javax.validation.ConstraintViolation;
 import javax.validation.Validator;
@@ -20,7 +19,7 @@ import org.springframework.data.jpa.mapping.JpaMetamodelMappingContext;
 
 @WebMvcTest(value = SurveyController.class, useDefaultFilters = false)
 @MockBean(JpaMetamodelMappingContext.class)
-public class SurveyRequestDtoValidTest implements CommonTestMethod{
+public class SurveyRequestDtoValidTest implements CommonTestMethod {
 
     @Autowired
     private Validator validator;
@@ -36,13 +35,13 @@ public class SurveyRequestDtoValidTest implements CommonTestMethod{
             .questionNo(1)
             .isRequired(true)
             .build();
-        List<QuestionRequestDto> questions = Arrays.asList(questionRequestDto);
+
         SurveyRequestDto surveyRequestDto = SurveyRequestDto.builder()
             .title("This is test title.")
             .description("This is test description")
             .startedDate(LocalDateTime.now())
             .endedDate(LocalDateTime.now().plusHours(1))
-            .questions(questions)
+            .questions(Arrays.asList(questionRequestDto))
             .build();
 
         // when
@@ -55,14 +54,14 @@ public class SurveyRequestDtoValidTest implements CommonTestMethod{
 
     @Override
     @Test
-    public void testValidateNullInput() {
+    public void testValidateNotNull() {
         // given
         SurveyRequestDto surveyRequestDto = SurveyRequestDto.builder()
-            .title(null)
-            .description(null)
-            .startedDate(null)
-            .endedDate(null)
-            .questions(null) // validate both @NotNull and @NotEmpty
+            .title(null) // violated by @NotBlank
+            .description(null) // violated by @NotBlank
+            .startedDate(null) // violated by @NotNull
+            .endedDate(null) // violated by @NotNull
+            .questions(null) // violated by @NotEmpty
             .build();
 
         // when
@@ -70,8 +69,7 @@ public class SurveyRequestDtoValidTest implements CommonTestMethod{
             surveyRequestDto);
 
         // then
-        assertEquals(validateSet.size(), 6);
-
+        assertEquals(validateSet.size(), 5); // violated total 5 constraints
     }
 
     @Override
@@ -83,6 +81,7 @@ public class SurveyRequestDtoValidTest implements CommonTestMethod{
             maxLengthStringBuilder.append("Test String.....");
         }
         String maxLengthString = maxLengthStringBuilder.toString();
+
         QuestionRequestDto questionRequestDto = QuestionRequestDto.builder()
             .title("This is test QuestionRequestDto")
             .description("This is test QuestionRequestDto")
@@ -90,13 +89,13 @@ public class SurveyRequestDtoValidTest implements CommonTestMethod{
             .questionNo(1)
             .isRequired(true)
             .build();
-        List<QuestionRequestDto> questions = Arrays.asList(questionRequestDto);
+
         SurveyRequestDto surveyRequestDto = SurveyRequestDto.builder()
-            .title(maxLengthString)
-            .description(maxLengthString)
+            .title(maxLengthString) // violated by @Size
+            .description(maxLengthString) // violated by @Size
             .startedDate(LocalDateTime.now())
             .endedDate(LocalDateTime.now().plusHours(1))
-            .questions(questions)
+            .questions(Arrays.asList(questionRequestDto))
             .build();
 
         // when
@@ -104,19 +103,19 @@ public class SurveyRequestDtoValidTest implements CommonTestMethod{
             surveyRequestDto);
 
         // then
-        assertEquals(validateSet.size(), 2);
+        assertEquals(validateSet.size(), 2); // violated total 2 constraints
     }
 
     @Override
     @Test
     public void testValidateNotBlank() {
-        List<QuestionRequestDto> emptyQuestions = new ArrayList<>();
+        // given
         SurveyRequestDto surveyRequestDto = SurveyRequestDto.builder()
-            .title("")
-            .description("")
+            .title(" ") // violated by @NotBlank
+            .description(" ") // violated by @NotBlank
             .startedDate(LocalDateTime.now())
             .endedDate(LocalDateTime.now().plusHours(1))
-            .questions(emptyQuestions) // validate @NotEmpty
+            .questions(new ArrayList<>()) // violated by @NotEmpty
             .build();
 
         // when
@@ -124,7 +123,27 @@ public class SurveyRequestDtoValidTest implements CommonTestMethod{
             surveyRequestDto);
 
         // then
-        assertEquals(validateSet.size(), 3);
+        assertEquals(validateSet.size(), 3); // violated total 3 constraints
+    }
+
+    @Override
+    @Test
+    public void testValidateNotEmpty() {
+        // given
+        SurveyRequestDto surveyRequestDto = SurveyRequestDto.builder()
+            .title("") // violated by @NotBlank
+            .description("") // violated by @NotBlank
+            .startedDate(LocalDateTime.now())
+            .endedDate(LocalDateTime.now().plusHours(1))
+            .questions(new ArrayList<>()) // violated by @NotEmpty
+            .build();
+
+        // when
+        Set<ConstraintViolation<SurveyRequestDto>> validateSet = validator.validate(
+            surveyRequestDto);
+
+        // then
+        assertEquals(validateSet.size(), 3); // violated total 3 constraints
     }
 
     @Test
@@ -137,13 +156,13 @@ public class SurveyRequestDtoValidTest implements CommonTestMethod{
             .questionNo(1)
             .isRequired(true)
             .build();
-        List<QuestionRequestDto> questions = Arrays.asList(questionRequestDto);
+
         SurveyRequestDto surveyRequestDto = SurveyRequestDto.builder()
             .title("This is test title.")
             .description("This is test description.")
             .startedDate(LocalDateTime.now())
             .endedDate(LocalDateTime.now().minusHours(1))
-            .questions(questions)
+            .questions(Arrays.asList(questionRequestDto))
             .build();
 
         // when

--- a/api/src/test/java/com/thesurvey/api/dto/SurveyUpdateRequestDtoValidTest.java
+++ b/api/src/test/java/com/thesurvey/api/dto/SurveyUpdateRequestDtoValidTest.java
@@ -59,6 +59,7 @@ public class SurveyUpdateRequestDtoValidTest implements CommonTestMethod{
     @Override
     @Test
     public void testValidateNullInput() {
+        // given
         SurveyUpdateRequestDto surveyUpdateRequestDto = SurveyUpdateRequestDto.builder()
             .surveyId(null)
             .title(null)

--- a/api/src/test/java/com/thesurvey/api/dto/SurveyUpdateRequestDtoValidTest.java
+++ b/api/src/test/java/com/thesurvey/api/dto/SurveyUpdateRequestDtoValidTest.java
@@ -6,7 +6,6 @@ import com.thesurvey.api.domain.EnumTypeEntity.QuestionType;
 import com.thesurvey.api.dto.request.QuestionBankUpdateRequestDto;
 import com.thesurvey.api.dto.request.SurveyUpdateRequestDto;
 import java.time.LocalDateTime;
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Set;
 import java.util.UUID;
@@ -20,12 +19,13 @@ import org.springframework.data.jpa.mapping.JpaMetamodelMappingContext;
 
 @WebMvcTest(value = SurveyController.class, useDefaultFilters = false)
 @MockBean(JpaMetamodelMappingContext.class)
-public class SurveyUpdateRequestDtoValidTest implements CommonTestMethod{
+public class SurveyUpdateRequestDtoValidTest {
 
     @Autowired
     private Validator validator;
 
-    @Override
+    final UUID surveyId = UUID.fromString("5eaa47c1-cba3-45da-9533-3528e18563c3");
+
     @Test
     public void testCorrectInput() {
         // given
@@ -39,7 +39,7 @@ public class SurveyUpdateRequestDtoValidTest implements CommonTestMethod{
             .build();
 
         SurveyUpdateRequestDto surveyUpdateRequestDto = SurveyUpdateRequestDto.builder()
-            .surveyId(UUID.fromString("5eaa47c1-cba3-45da-9533-3528e18563c3"))
+            .surveyId(surveyId)
             .title("This is test title.")
             .description("This is test description")
             .startedDate(LocalDateTime.now())
@@ -56,17 +56,11 @@ public class SurveyUpdateRequestDtoValidTest implements CommonTestMethod{
 
     }
 
-    @Override
     @Test
-    public void testValidateNullInput() {
+    public void testValidateNotNull() {
         // given
         SurveyUpdateRequestDto surveyUpdateRequestDto = SurveyUpdateRequestDto.builder()
-            .surveyId(null)
-            .title(null)
-            .description(null)
-            .startedDate(null)
-            .endedDate(null)
-            .questions(null) // validate both @NotNull and @NotEmpty
+            .surveyId(null) // validated by @NotNull
             .build();
 
         // when
@@ -74,10 +68,9 @@ public class SurveyUpdateRequestDtoValidTest implements CommonTestMethod{
             surveyUpdateRequestDto);
 
         // then
-        assertEquals(validateSet.size(), 7);
+        assertEquals(validateSet.size(), 1); // violated total 1 constraint
     }
 
-    @Override
     @Test
     public void testValidateOverMaxStringLength() {
         // given
@@ -87,22 +80,10 @@ public class SurveyUpdateRequestDtoValidTest implements CommonTestMethod{
         }
         String maxLengthString = maxLengthStringBuilder.toString();
 
-        QuestionBankUpdateRequestDto questionBankUpdateRequestDto = QuestionBankUpdateRequestDto.builder()
-            .questionBankId(1L)
-            .title("This is test QuestionBankUpdateRequestDto")
-            .description("This is test QuestionBankUpdateRequestDto")
-            .questionType(QuestionType.LONG_ANSWER)
-            .questionNo(1)
-            .isRequired(true)
-            .build();
-
         SurveyUpdateRequestDto surveyUpdateRequestDto = SurveyUpdateRequestDto.builder()
-            .surveyId(UUID.fromString("5eaa47c1-cba3-45da-9533-3528e18563c3"))
-            .title(maxLengthString)
-            .description(maxLengthString)
-            .startedDate(LocalDateTime.now())
-            .endedDate(LocalDateTime.now().plusDays(1))
-            .questions(Arrays.asList(questionBankUpdateRequestDto))
+            .surveyId(surveyId)
+            .title(maxLengthString) // violated by @Size
+            .description(maxLengthString) // violated by @Size
             .build();
 
         // when
@@ -110,49 +91,16 @@ public class SurveyUpdateRequestDtoValidTest implements CommonTestMethod{
             surveyUpdateRequestDto);
 
         // then
-        assertEquals(validateSet.size(), 2);
-    }
-
-    @Override
-    @Test
-    public void testValidateNotBlank() {
-        // given
-        SurveyUpdateRequestDto surveyUpdateRequestDto = SurveyUpdateRequestDto.builder()
-            .surveyId(UUID.fromString("5eaa47c1-cba3-45da-9533-3528e18563c3"))
-            .title("")
-            .description("")
-            .startedDate(LocalDateTime.now())
-            .endedDate(LocalDateTime.now().plusDays(1))
-            .questions(new ArrayList<>()) // validate @NotBlank
-            .build();
-
-        // when
-        Set<ConstraintViolation<SurveyUpdateRequestDto>> validateSet = validator.validate(
-            surveyUpdateRequestDto);
-
-        // then
-        assertEquals(validateSet.size(), 3);
+        assertEquals(validateSet.size(), 2); // violated total 2 constraints
     }
 
     @Test
     public void testValidateTime() {
         // given
-        QuestionBankUpdateRequestDto questionBankUpdateRequestDto = QuestionBankUpdateRequestDto.builder()
-            .questionBankId(1L)
-            .title("This is test QuestionBankUpdateRequestDto")
-            .description("This is test QuestionBankUpdateRequestDto")
-            .questionType(QuestionType.LONG_ANSWER)
-            .questionNo(1)
-            .isRequired(true)
-            .build();
-
         SurveyUpdateRequestDto surveyUpdateRequestDto = SurveyUpdateRequestDto.builder()
-            .surveyId(UUID.fromString("5eaa47c1-cba3-45da-9533-3528e18563c3"))
-            .title("This is test title")
-            .description("This is test description")
+            .surveyId(surveyId)
             .startedDate(LocalDateTime.now())
             .endedDate(LocalDateTime.now().minusDays(1))
-            .questions(Arrays.asList(questionBankUpdateRequestDto))
             .build();
 
         // when


### PR DESCRIPTION
**Modified**
- We have logic for survey that ensures if each property is null and if it's not, it updates that property. So `@NotNull`, `@NotBlank` or whatever options  should be removed from DTO.
- There doesn't need to be both `@NotNull` and `@NotBlank` or `@NotEmpty`. If there's `@NotBlank` it's all set.
- User authentication is duplicated since `@BeforEach` already satisfies it.

**Added**
- `@NotEmpty` validation for DTO

So we've got plenty of tests for dto logics like type validations. But there're not enough tests for business logic. e.g. Some unexpected events from users. @kimjinmyeong  could you add this tests for buisness logic?