### PR TITLE
feat: `UserCertification` 엔티티, 기능 구현

### DIFF
--- a/api/src/main/java/com/thesurvey/api/ApiApplication.java
+++ b/api/src/main/java/com/thesurvey/api/ApiApplication.java
@@ -3,9 +3,11 @@ package com.thesurvey.api;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
 @SpringBootApplication
 @EnableJpaAuditing
+@EnableScheduling
 public class ApiApplication {
 
     public static void main(String[] args) {

--- a/api/src/main/java/com/thesurvey/api/controller/UserController.java
+++ b/api/src/main/java/com/thesurvey/api/controller/UserController.java
@@ -1,15 +1,14 @@
 package com.thesurvey.api.controller;
 
 import com.thesurvey.api.dto.request.user.UserCertificationUpdateRequestDto;
-import com.thesurvey.api.dto.response.user.UserSurveyResultDto;
-import com.thesurvey.api.dto.response.user.UserResponseDto;
 import com.thesurvey.api.dto.request.user.UserUpdateRequestDto;
+import com.thesurvey.api.dto.response.user.UserResponseDto;
+import com.thesurvey.api.dto.response.user.UserSurveyResultDto;
 import com.thesurvey.api.dto.response.user.UserSurveyTitleDto;
 import com.thesurvey.api.dto.response.userCertification.UserCertificationListDto;
 import com.thesurvey.api.service.SurveyService;
 import com.thesurvey.api.service.UserCertificationService;
 import com.thesurvey.api.service.UserService;
-
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Content;
@@ -17,22 +16,14 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
-
-import java.util.List;
-import java.util.UUID;
-
-import javax.validation.Valid;
-
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.Authentication;
-import org.springframework.web.bind.annotation.DeleteMapping;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PatchMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
+
+import javax.validation.Valid;
+import java.util.List;
+import java.util.UUID;
 
 @Tag(name = "사용자", description = "User Controller")
 @RestController
@@ -46,7 +37,7 @@ public class UserController {
     private final SurveyService surveyService;
 
     public UserController(UserService userService,
-        UserCertificationService userCertificationService, SurveyService surveyService) {
+                          UserCertificationService userCertificationService, SurveyService surveyService) {
         this.userService = userService;
         this.userCertificationService = userCertificationService;
         this.surveyService = surveyService;
@@ -54,106 +45,106 @@ public class UserController {
 
     @Operation(summary = "사용자 정보 조회", description = "요청한 사용자의 정보를 가져옵니다.")
     @ApiResponses(value = {
-        @ApiResponse(responseCode = "200", description = "요청 성공"),
-        @ApiResponse(responseCode = "400", description = "잘못된 요청", content = @Content(schema = @Schema(hidden = true))),
-        @ApiResponse(responseCode = "401", description = "사용자 인증 실패", content = @Content(schema = @Schema(hidden = true))),
-        @ApiResponse(responseCode = "403", description = "접근 권한 없음", content = @Content(schema = @Schema(hidden = true))),
-        @ApiResponse(responseCode = "404", description = "요청한 리소스 찾을 수 없음", content = @Content(schema = @Schema(hidden = true)))
+            @ApiResponse(responseCode = "200", description = "요청 성공"),
+            @ApiResponse(responseCode = "400", description = "잘못된 요청", content = @Content(schema = @Schema(hidden = true))),
+            @ApiResponse(responseCode = "401", description = "사용자 인증 실패", content = @Content(schema = @Schema(hidden = true))),
+            @ApiResponse(responseCode = "403", description = "접근 권한 없음", content = @Content(schema = @Schema(hidden = true))),
+            @ApiResponse(responseCode = "404", description = "요청한 리소스 찾을 수 없음", content = @Content(schema = @Schema(hidden = true)))
     })
     @GetMapping("/profile")
     public ResponseEntity<UserResponseDto> getUserProfile(
-        @Parameter(hidden = true) Authentication authentication) {
+            @Parameter(hidden = true) Authentication authentication) {
         return ResponseEntity.ok(userService.getUserProfile(authentication));
     }
 
     @Operation(summary = "사용자 설문조사 목록 조회", description = "사용자가 생성한 설문조사 목록을 가져옵니다.")
     @ApiResponses(value = {
-        @ApiResponse(responseCode = "200", description = "요청 성공"),
-        @ApiResponse(responseCode = "400", description = "잘못된 요청", content = @Content(schema = @Schema(hidden = true))),
-        @ApiResponse(responseCode = "401", description = "사용자 인증 실패", content = @Content(schema = @Schema(hidden = true))),
-        @ApiResponse(responseCode = "403", description = "접근 권한 없음", content = @Content(schema = @Schema(hidden = true))),
-        @ApiResponse(responseCode = "404", description = "요청한 리소스 찾을 수 없음", content = @Content(schema = @Schema(hidden = true)))
+            @ApiResponse(responseCode = "200", description = "요청 성공"),
+            @ApiResponse(responseCode = "400", description = "잘못된 요청", content = @Content(schema = @Schema(hidden = true))),
+            @ApiResponse(responseCode = "401", description = "사용자 인증 실패", content = @Content(schema = @Schema(hidden = true))),
+            @ApiResponse(responseCode = "403", description = "접근 권한 없음", content = @Content(schema = @Schema(hidden = true))),
+            @ApiResponse(responseCode = "404", description = "요청한 리소스 찾을 수 없음", content = @Content(schema = @Schema(hidden = true)))
     })
     @GetMapping("/surveys")
     public ResponseEntity<List<UserSurveyTitleDto>> getUserCreatedSurveys(
-        @Parameter(hidden = true) Authentication authentication) {
+            @Parameter(hidden = true) Authentication authentication) {
         return ResponseEntity.ok(surveyService.getUserCreatedSurveys(authentication));
     }
 
     @Operation(summary = "사용자 설문조사 결과 조회", description = "사용자가 생성한 설문조사 결과를 가져옵니다.")
     @ApiResponses(value = {
-        @ApiResponse(responseCode = "200", description = "요청 성공"),
-        @ApiResponse(responseCode = "400", description = "잘못된 요청", content = @Content(schema = @Schema(hidden = true))),
-        @ApiResponse(responseCode = "401", description = "사용자 인증 실패", content = @Content(schema = @Schema(hidden = true))),
-        @ApiResponse(responseCode = "403", description = "접근 권한 없음", content = @Content(schema = @Schema(hidden = true))),
-        @ApiResponse(responseCode = "404", description = "요청한 리소스 찾을 수 없음", content = @Content(schema = @Schema(hidden = true)))
+            @ApiResponse(responseCode = "200", description = "요청 성공"),
+            @ApiResponse(responseCode = "400", description = "잘못된 요청", content = @Content(schema = @Schema(hidden = true))),
+            @ApiResponse(responseCode = "401", description = "사용자 인증 실패", content = @Content(schema = @Schema(hidden = true))),
+            @ApiResponse(responseCode = "403", description = "접근 권한 없음", content = @Content(schema = @Schema(hidden = true))),
+            @ApiResponse(responseCode = "404", description = "요청한 리소스 찾을 수 없음", content = @Content(schema = @Schema(hidden = true)))
     })
     @GetMapping("/surveys/{surveyId}")
     public ResponseEntity<UserSurveyResultDto> getUserCreatedSurveyResult(
-        @Parameter(hidden = true) Authentication authentication,
-        @PathVariable("surveyId") UUID surveyId) {
+            @Parameter(hidden = true) Authentication authentication,
+            @PathVariable("surveyId") UUID surveyId) {
         return ResponseEntity.ok(
-            surveyService.getUserCreatedSurveyResult(authentication, surveyId));
+                surveyService.getUserCreatedSurveyResult(authentication, surveyId));
     }
 
     @Operation(summary = "사용자 정보 수정", description = "요청한 사용자의 정보를 수정합니다.")
     @ApiResponses(value = {
-        @ApiResponse(responseCode = "200", description = "요청 성공"),
-        @ApiResponse(responseCode = "400", description = "잘못된 요청", content = @Content(schema = @Schema(hidden = true))),
-        @ApiResponse(responseCode = "401", description = "사용자 인증 실패", content = @Content(schema = @Schema(hidden = true))),
-        @ApiResponse(responseCode = "403", description = "접근 권한 없음", content = @Content(schema = @Schema(hidden = true))),
-        @ApiResponse(responseCode = "404", description = "요청한 리소스 찾을 수 없음", content = @Content(schema = @Schema(hidden = true)))
+            @ApiResponse(responseCode = "200", description = "요청 성공"),
+            @ApiResponse(responseCode = "400", description = "잘못된 요청", content = @Content(schema = @Schema(hidden = true))),
+            @ApiResponse(responseCode = "401", description = "사용자 인증 실패", content = @Content(schema = @Schema(hidden = true))),
+            @ApiResponse(responseCode = "403", description = "접근 권한 없음", content = @Content(schema = @Schema(hidden = true))),
+            @ApiResponse(responseCode = "404", description = "요청한 리소스 찾을 수 없음", content = @Content(schema = @Schema(hidden = true)))
     })
     @PatchMapping("/profile")
     public ResponseEntity<UserResponseDto> updateUserProfile(
-        @Parameter(hidden = true) Authentication authentication,
-        @RequestBody UserUpdateRequestDto userUpdateRequestDto) {
+            @Parameter(hidden = true) Authentication authentication,
+            @RequestBody UserUpdateRequestDto userUpdateRequestDto) {
         return ResponseEntity.ok(
-            userService.updateUserProfile(authentication, userUpdateRequestDto));
+                userService.updateUserProfile(authentication, userUpdateRequestDto));
     }
 
     @Operation(summary = "사용자 인증 정보 조회", description = "사용자의 인증 정보를 조회합니다.")
     @ApiResponses(value = {
-        @ApiResponse(responseCode = "200", description = "요청 성공"),
-        @ApiResponse(responseCode = "400", description = "잘못된 요청", content = @Content(schema = @Schema(hidden = true))),
-        @ApiResponse(responseCode = "401", description = "사용자 인증 실패", content = @Content(schema = @Schema(hidden = true))),
-        @ApiResponse(responseCode = "403", description = "접근 권한 없음", content = @Content(schema = @Schema(hidden = true))),
-        @ApiResponse(responseCode = "404", description = "요청한 리소스 찾을 수 없음", content = @Content(schema = @Schema(hidden = true)))
+            @ApiResponse(responseCode = "200", description = "요청 성공"),
+            @ApiResponse(responseCode = "400", description = "잘못된 요청", content = @Content(schema = @Schema(hidden = true))),
+            @ApiResponse(responseCode = "401", description = "사용자 인증 실패", content = @Content(schema = @Schema(hidden = true))),
+            @ApiResponse(responseCode = "403", description = "접근 권한 없음", content = @Content(schema = @Schema(hidden = true))),
+            @ApiResponse(responseCode = "404", description = "요청한 리소스 찾을 수 없음", content = @Content(schema = @Schema(hidden = true)))
     })
-    @GetMapping("/profile/auth-list")
+    @GetMapping("/profile/certifications")
     public ResponseEntity<UserCertificationListDto> getUserCertification(
-        @Parameter(hidden = true) Authentication authentication) {
+            @Parameter(hidden = true) Authentication authentication) {
         return ResponseEntity.ok(
-            userCertificationService.getUserCertifications(authentication));
+                userCertificationService.getUserCertifications(authentication));
     }
 
     @Operation(summary = "사용자 인증 정보 수정", description = "사용자의 인증 정보를 수정합니다.")
     @ApiResponses(value = {
-        @ApiResponse(responseCode = "200", description = "요청 성공"),
-        @ApiResponse(responseCode = "400", description = "잘못된 요청", content = @Content(schema = @Schema(hidden = true))),
-        @ApiResponse(responseCode = "401", description = "사용자 인증 실패", content = @Content(schema = @Schema(hidden = true))),
-        @ApiResponse(responseCode = "403", description = "접근 권한 없음", content = @Content(schema = @Schema(hidden = true))),
-        @ApiResponse(responseCode = "404", description = "요청한 리소스 찾을 수 없음", content = @Content(schema = @Schema(hidden = true)))
+            @ApiResponse(responseCode = "200", description = "요청 성공"),
+            @ApiResponse(responseCode = "400", description = "잘못된 요청", content = @Content(schema = @Schema(hidden = true))),
+            @ApiResponse(responseCode = "401", description = "사용자 인증 실패", content = @Content(schema = @Schema(hidden = true))),
+            @ApiResponse(responseCode = "403", description = "접근 권한 없음", content = @Content(schema = @Schema(hidden = true))),
+            @ApiResponse(responseCode = "404", description = "요청한 리소스 찾을 수 없음", content = @Content(schema = @Schema(hidden = true)))
     })
-    @PatchMapping("/profile/authentications")
+    @PatchMapping("/profile/certifications")
     public ResponseEntity<UserCertificationListDto> updateUserCertification(
-        @Parameter(hidden = true) Authentication authentication,
-        @RequestBody @Valid UserCertificationUpdateRequestDto userCertificationUpdateRequestDto) {
+            @Parameter(hidden = true) Authentication authentication,
+            @RequestBody @Valid UserCertificationUpdateRequestDto userCertificationUpdateRequestDto) {
         return ResponseEntity.ok(
-            userCertificationService.updateUserCertification(authentication, userCertificationUpdateRequestDto));
+                userCertificationService.updateUserCertification(authentication, userCertificationUpdateRequestDto));
     }
 
     @Operation(summary = "사용자 삭제", description = "요청한 사용자의 정보를 삭제합니다.")
     @ApiResponses(value = {
-        @ApiResponse(responseCode = "204", description = "요청 성공"),
-        @ApiResponse(responseCode = "400", description = "잘못된 요청", content = @Content(schema = @Schema(hidden = true))),
-        @ApiResponse(responseCode = "401", description = "사용자 인증 실패", content = @Content(schema = @Schema(hidden = true))),
-        @ApiResponse(responseCode = "403", description = "접근 권한 없음", content = @Content(schema = @Schema(hidden = true))),
-        @ApiResponse(responseCode = "404", description = "요청한 리소스 찾을 수 없음", content = @Content(schema = @Schema(hidden = true)))
+            @ApiResponse(responseCode = "204", description = "요청 성공"),
+            @ApiResponse(responseCode = "400", description = "잘못된 요청", content = @Content(schema = @Schema(hidden = true))),
+            @ApiResponse(responseCode = "401", description = "사용자 인증 실패", content = @Content(schema = @Schema(hidden = true))),
+            @ApiResponse(responseCode = "403", description = "접근 권한 없음", content = @Content(schema = @Schema(hidden = true))),
+            @ApiResponse(responseCode = "404", description = "요청한 리소스 찾을 수 없음", content = @Content(schema = @Schema(hidden = true)))
     })
     @DeleteMapping
     public ResponseEntity<Void> deleteUser(
-        @Parameter(hidden = true) Authentication authentication) {
+            @Parameter(hidden = true) Authentication authentication) {
         userService.deleteUser(authentication);
         return ResponseEntity.status(HttpStatus.NO_CONTENT).build();
     }

--- a/api/src/main/java/com/thesurvey/api/controller/UserController.java
+++ b/api/src/main/java/com/thesurvey/api/controller/UserController.java
@@ -1,10 +1,13 @@
 package com.thesurvey.api.controller;
 
+import com.thesurvey.api.dto.request.user.UserCertificationUpdateRequestDto;
 import com.thesurvey.api.dto.response.user.UserSurveyResultDto;
 import com.thesurvey.api.dto.response.user.UserResponseDto;
 import com.thesurvey.api.dto.request.user.UserUpdateRequestDto;
 import com.thesurvey.api.dto.response.user.UserSurveyTitleDto;
+import com.thesurvey.api.dto.response.userCertification.UserCertificationListDto;
 import com.thesurvey.api.service.SurveyService;
+import com.thesurvey.api.service.UserCertificationService;
 import com.thesurvey.api.service.UserService;
 
 import io.swagger.v3.oas.annotations.Operation;
@@ -17,6 +20,8 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 
 import java.util.List;
 import java.util.UUID;
+
+import javax.validation.Valid;
 
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -36,10 +41,14 @@ public class UserController {
 
     private final UserService userService;
 
+    private final UserCertificationService userCertificationService;
+
     private final SurveyService surveyService;
 
-    public UserController(UserService userService, SurveyService surveyService) {
+    public UserController(UserService userService,
+        UserCertificationService userCertificationService, SurveyService surveyService) {
         this.userService = userService;
+        this.userCertificationService = userCertificationService;
         this.surveyService = surveyService;
     }
 
@@ -101,6 +110,37 @@ public class UserController {
         @RequestBody UserUpdateRequestDto userUpdateRequestDto) {
         return ResponseEntity.ok(
             userService.updateUserProfile(authentication, userUpdateRequestDto));
+    }
+
+    @Operation(summary = "사용자 인증 정보 조회", description = "사용자의 인증 정보를 조회합니다.")
+    @ApiResponses(value = {
+        @ApiResponse(responseCode = "200", description = "요청 성공"),
+        @ApiResponse(responseCode = "400", description = "잘못된 요청", content = @Content(schema = @Schema(hidden = true))),
+        @ApiResponse(responseCode = "401", description = "사용자 인증 실패", content = @Content(schema = @Schema(hidden = true))),
+        @ApiResponse(responseCode = "403", description = "접근 권한 없음", content = @Content(schema = @Schema(hidden = true))),
+        @ApiResponse(responseCode = "404", description = "요청한 리소스 찾을 수 없음", content = @Content(schema = @Schema(hidden = true)))
+    })
+    @GetMapping("/profile/auth-list")
+    public ResponseEntity<UserCertificationListDto> getUserCertification(
+        @Parameter(hidden = true) Authentication authentication) {
+        return ResponseEntity.ok(
+            userCertificationService.getUserCertifications(authentication));
+    }
+
+    @Operation(summary = "사용자 인증 정보 수정", description = "사용자의 인증 정보를 수정합니다.")
+    @ApiResponses(value = {
+        @ApiResponse(responseCode = "200", description = "요청 성공"),
+        @ApiResponse(responseCode = "400", description = "잘못된 요청", content = @Content(schema = @Schema(hidden = true))),
+        @ApiResponse(responseCode = "401", description = "사용자 인증 실패", content = @Content(schema = @Schema(hidden = true))),
+        @ApiResponse(responseCode = "403", description = "접근 권한 없음", content = @Content(schema = @Schema(hidden = true))),
+        @ApiResponse(responseCode = "404", description = "요청한 리소스 찾을 수 없음", content = @Content(schema = @Schema(hidden = true)))
+    })
+    @PatchMapping("/profile/authentications")
+    public ResponseEntity<UserCertificationListDto> updateUserCertification(
+        @Parameter(hidden = true) Authentication authentication,
+        @RequestBody @Valid UserCertificationUpdateRequestDto userCertificationUpdateRequestDto) {
+        return ResponseEntity.ok(
+            userCertificationService.updateUserCertification(authentication, userCertificationUpdateRequestDto));
     }
 
     @Operation(summary = "사용자 삭제", description = "요청한 사용자의 정보를 삭제합니다.")

--- a/api/src/main/java/com/thesurvey/api/domain/User.java
+++ b/api/src/main/java/com/thesurvey/api/domain/User.java
@@ -63,6 +63,13 @@ public class User extends BaseTimeEntity implements UserDetails {
         cascade = CascadeType.ALL,
         orphanRemoval = true
     )
+    private List<UserCertification> userCertifications;
+
+    @OneToMany(
+        mappedBy = "user",
+        cascade = CascadeType.ALL,
+        orphanRemoval = true
+    )
     private List<PointHistory> pointHistories;
 
     /**
@@ -106,11 +113,13 @@ public class User extends BaseTimeEntity implements UserDetails {
 
     @Builder
     public User(List<Participation> participations, List<AnsweredQuestion> answeredQuestions,
-        List<PointHistory> pointHistories, String email, String name, String password,
+        List<UserCertification> userCertification,
+        List<PointHistory>pointHistories, String email, String name, String password,
         String phoneNumber, String address, String profileImage) {
         this.participations = participations;
         this.answeredQuestions = answeredQuestions;
         this.pointHistories = pointHistories;
+        this.userCertifications = userCertification;
         this.email = email;
         this.name = name;
         this.password = password;

--- a/api/src/main/java/com/thesurvey/api/domain/UserCertification.java
+++ b/api/src/main/java/com/thesurvey/api/domain/UserCertification.java
@@ -1,0 +1,60 @@
+package com.thesurvey.api.domain;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.thesurvey.api.domain.EnumTypeEntity.CertificationType;
+
+import java.time.LocalDateTime;
+
+import javax.persistence.Column;
+import javax.persistence.EmbeddedId;
+import javax.persistence.Entity;
+import javax.persistence.FetchType;
+import javax.persistence.JoinColumn;
+import javax.persistence.ManyToOne;
+import javax.persistence.Table;
+import javax.validation.Valid;
+
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@Table(name = "user_certification")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class UserCertification {
+
+    @EmbeddedId
+    private UserCertificationId userCertificationId;
+
+    @Valid
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", insertable = false, updatable = false)
+    private User user;
+
+    @Column(name = "certification_type", insertable = false, updatable = false)
+    private CertificationType certificationType;
+
+    @Column(name = "certification_date", nullable = false)
+    @JsonFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss")
+    private LocalDateTime certificationDate;
+
+    @Column(name = "expiration_date", nullable = false)
+    @JsonFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss")
+    private LocalDateTime expirationDate;
+
+    @Builder
+    public UserCertification(User user, CertificationType certificationType,
+        LocalDateTime certificationDate, LocalDateTime expirationDate) {
+        this.user = user;
+        this.certificationType = certificationType;
+        this.certificationDate = certificationDate;
+        this.userCertificationId = UserCertificationId.builder()
+            .userId(user.getUserId())
+            .certificationType(certificationType)
+            .build();
+        this.expirationDate = expirationDate;
+    }
+
+}

--- a/api/src/main/java/com/thesurvey/api/domain/UserCertificationId.java
+++ b/api/src/main/java/com/thesurvey/api/domain/UserCertificationId.java
@@ -1,0 +1,53 @@
+package com.thesurvey.api.domain;
+
+import com.thesurvey.api.domain.EnumTypeEntity.CertificationType;
+import java.io.Serializable;
+import java.util.Objects;
+import javax.persistence.Column;
+import javax.persistence.Embeddable;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Embeddable
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class UserCertificationId implements Serializable {
+
+    @Column(name = "user_id")
+    private Long userId;
+
+    /*
+     * the value of id is set to the index of EnumTypeEntity.CertificationType.
+     * the value of id : CertificationType
+     * 0: NONE, 1: KAKAO, 2: NAVER, 3: GOOGLE, 4: WEBMAIL, 5: DRIVER_LICENSE, 6: IDENTITY_CARD
+     */
+    @Column(name = "certification_type")
+    private CertificationType certificationType;
+
+    @Builder
+    public UserCertificationId(Long userId, CertificationType certificationType) {
+        this.userId = userId;
+        this.certificationType = certificationType;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        UserCertificationId that = (UserCertificationId) o;
+        return Objects.equals(userId, that.userId) && Objects.equals(certificationType,
+            that.certificationType);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(userId, certificationType);
+    }
+
+}

--- a/api/src/main/java/com/thesurvey/api/dto/request/answeredQuestion/AnsweredQuestionRequestDto.java
+++ b/api/src/main/java/com/thesurvey/api/dto/request/answeredQuestion/AnsweredQuestionRequestDto.java
@@ -24,7 +24,4 @@ public class AnsweredQuestionRequestDto {
     @Schema(example = "93c0a231-207e-4190-aee9-0a5f78cafc44", description = "수정하려는 설문조사의 아이디입니다.")
     private UUID surveyId;
 
-    @Schema(example = "[\"NAVER\", \"KAKAO\"]", description = "설문 참가자의 인증 유형을 지정합니다. 인증 유형은 다음의 값들이 올 수 있습니다: [\"NAVER\", \"KAKAO\", \"GOGLE\", \"WEBMAIL\", \"DRIVER_LICENSE\", \"MOBILE_PHONE\"]")
-    private List<@Valid CertificationType> certificationTypes;
-
 }

--- a/api/src/main/java/com/thesurvey/api/dto/request/user/UserCertificationUpdateRequestDto.java
+++ b/api/src/main/java/com/thesurvey/api/dto/request/user/UserCertificationUpdateRequestDto.java
@@ -1,0 +1,37 @@
+package com.thesurvey.api.dto.request.user;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import javax.validation.constraints.NotNull;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class UserCertificationUpdateRequestDto {
+
+    @NotNull
+    @Schema(example = "true", description = "카카오 인증 여부입니다.")
+    private Boolean isKakaoCertificated;
+
+    @NotNull
+    @Schema(example = "false", description = "네이버 인증 여부입니다.")
+    private Boolean isNaverCertificated;
+
+    @NotNull
+    @Schema(example = "true", description = "구글 인증 여부입니다.")
+    private Boolean isGoogleCertificated;
+
+    @NotNull
+    @Schema(example = "true", description = "웹메일 인증 여부입니다.")
+    private Boolean isWebMailCertificated;
+
+    @NotNull
+    @Schema(example = "false", description = "운전면허 인증 여부입니다.")
+    private Boolean isDriverLicenseCertificated;
+
+    @NotNull
+    @Schema(example = "false", description = "신분증 인증 여부입니다.")
+    private Boolean isIdentityCardCertificated;
+
+}

--- a/api/src/main/java/com/thesurvey/api/dto/response/userCertification/DriverLicenseCertificationInfoDto.java
+++ b/api/src/main/java/com/thesurvey/api/dto/response/userCertification/DriverLicenseCertificationInfoDto.java
@@ -1,0 +1,21 @@
+package com.thesurvey.api.dto.response.userCertification;
+
+import java.time.LocalDateTime;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class DriverLicenseCertificationInfoDto {
+
+    @Schema(example = "false", description = "운전면허증 인증 여부입니다.")
+    private Boolean isCertificated;
+
+    @Schema(example = "2023-04-22T00:00:00", description = "운전면허증 인증 만료 날짜입니다.")
+    @JsonFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss")
+    private LocalDateTime expirationDate;
+
+}

--- a/api/src/main/java/com/thesurvey/api/dto/response/userCertification/GoogleCertificationInfoDto.java
+++ b/api/src/main/java/com/thesurvey/api/dto/response/userCertification/GoogleCertificationInfoDto.java
@@ -1,0 +1,21 @@
+package com.thesurvey.api.dto.response.userCertification;
+
+import java.time.LocalDateTime;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class GoogleCertificationInfoDto {
+
+    @Schema(example = "true", description = "구글 인증 여부입니다.")
+    private Boolean isCertificated;
+
+    @Schema(example = "2023-04-22T00:00:00", description = "구글 인증 만료 날짜입니다.")
+    @JsonFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss")
+    private LocalDateTime expirationDate;
+
+}

--- a/api/src/main/java/com/thesurvey/api/dto/response/userCertification/IdentityCardCertificationInfoDto.java
+++ b/api/src/main/java/com/thesurvey/api/dto/response/userCertification/IdentityCardCertificationInfoDto.java
@@ -1,0 +1,21 @@
+package com.thesurvey.api.dto.response.userCertification;
+
+import java.time.LocalDateTime;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class IdentityCardCertificationInfoDto {
+
+    @Schema(example = "false", description = "신분증 인증 여부입니다.")
+    private Boolean isCertificated;
+
+    @Schema(example = "2023-04-22T00:00:00", description = "신분증 인증 만료 날짜입니다.")
+    @JsonFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss")
+    private LocalDateTime expirationDate;
+
+}

--- a/api/src/main/java/com/thesurvey/api/dto/response/userCertification/KakaoCertificationInfoDto.java
+++ b/api/src/main/java/com/thesurvey/api/dto/response/userCertification/KakaoCertificationInfoDto.java
@@ -1,0 +1,22 @@
+package com.thesurvey.api.dto.response.userCertification;
+
+import java.time.LocalDateTime;
+
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class KakaoCertificationInfoDto {
+
+    @Schema(example = "true", description = "카카오 인증 여부입니다.")
+    private Boolean isCertificated;
+
+    @Schema(example = "2023-04-22T00:00:00", description = "카카오 인증 만료 날짜입니다.")
+    @JsonFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss")
+    private LocalDateTime expirationDate;
+
+}

--- a/api/src/main/java/com/thesurvey/api/dto/response/userCertification/NaverCertificationInfoDto.java
+++ b/api/src/main/java/com/thesurvey/api/dto/response/userCertification/NaverCertificationInfoDto.java
@@ -1,0 +1,21 @@
+package com.thesurvey.api.dto.response.userCertification;
+
+import java.time.LocalDateTime;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class NaverCertificationInfoDto {
+
+    @Schema(example = "false", description = "네이버 인증 여부입니다.")
+    private Boolean isCertificated;
+
+    @Schema(example = "2023-04-22T00:00:00", description = "네이버 인증 만료 날짜입니다.")
+    @JsonFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss")
+    private LocalDateTime expirationDate;
+
+}

--- a/api/src/main/java/com/thesurvey/api/dto/response/userCertification/UserCertificationListDto.java
+++ b/api/src/main/java/com/thesurvey/api/dto/response/userCertification/UserCertificationListDto.java
@@ -1,0 +1,31 @@
+package com.thesurvey.api.dto.response.userCertification;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+public class UserCertificationListDto {
+
+    @Schema(description = "카카오 인증 정보입니다.")
+    private KakaoCertificationInfoDto kakaoCertificationInfo;
+
+    @Schema(description = "네이버 인증 정보입니다.")
+    private NaverCertificationInfoDto naverCertificationInfo;
+
+    @Schema(description = "구글 인증 정보입니다.")
+    private GoogleCertificationInfoDto googleCertificationInfo;
+
+    @Schema(description = "웹메일 인증 정보입니다.")
+    private WebMailCertificationInfoDto webMailCertificationInfo;
+
+    @Schema(description = "운전면허증 인증 정보입니다.")
+    private DriverLicenseCertificationInfoDto driverLicenseCertificationInfo;
+
+    @Schema(description = "신분증 인증 정보입니다.")
+    private IdentityCardCertificationInfoDto identityCardCertificationInfo;
+
+}

--- a/api/src/main/java/com/thesurvey/api/dto/response/userCertification/WebMailCertificationInfoDto.java
+++ b/api/src/main/java/com/thesurvey/api/dto/response/userCertification/WebMailCertificationInfoDto.java
@@ -1,0 +1,21 @@
+package com.thesurvey.api.dto.response.userCertification;
+
+import java.time.LocalDateTime;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class WebMailCertificationInfoDto {
+
+    @Schema(example = "true", description = "웹메일 인증 여부입니다.")
+    private Boolean isCertificated;
+
+    @Schema(example = "2025-04-22T00:00:00", description = "웹메일 인증 만료 날짜입니다.")
+    @JsonFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss")
+    private LocalDateTime expirationDate;
+
+}

--- a/api/src/main/java/com/thesurvey/api/exception/ErrorMessage.java
+++ b/api/src/main/java/com/thesurvey/api/exception/ErrorMessage.java
@@ -26,7 +26,7 @@ public enum ErrorMessage {
     NOT_SURVEY_QUESTION("해당 설문조사의 질문이 아닙니다."),
     INVALID_REQUEST("유효하지 않은 요청입니다"),
     PAGE_NOT_FOUND("존재하지 않는 페이지입니다."),
-    USER_CREATED_SURVEY_NOT_FOUND("생성한 설문조사가 없습니다.");
+    CERTIFICATION_NOT_COMPLETED("설문조사에 필요한 인증을 하지 않았습니다.");
 
     private final String message;
 

--- a/api/src/main/java/com/thesurvey/api/repository/SurveyRepository.java
+++ b/api/src/main/java/com/thesurvey/api/repository/SurveyRepository.java
@@ -28,4 +28,7 @@ public interface SurveyRepository extends JpaRepository<Survey, UUID> {
     @Query("SELECT new com.thesurvey.api.dto.response.user.UserSurveyTitleDto(s.surveyId, s.title) FROM Survey s WHERE s.authorId = :author_id ORDER BY s.createdDate DESC")
     List<UserSurveyTitleDto> findUserCreatedSurveysByAuthorID(@Param("author_id") Long authorId);
 
+    @Query("SELECT p.certificationType FROM Participation p WHERE p.survey.surveyId = :surveyId AND p.user.userId = :authorId")
+    List<Integer> findCertificationTypeBySurveyIdAndAuthorId(UUID surveyId, Long authorId);
+
 }

--- a/api/src/main/java/com/thesurvey/api/repository/UserCertificationRepository.java
+++ b/api/src/main/java/com/thesurvey/api/repository/UserCertificationRepository.java
@@ -1,0 +1,22 @@
+package com.thesurvey.api.repository;
+
+import com.thesurvey.api.domain.UserCertification;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface UserCertificationRepository extends JpaRepository<UserCertification, Long> {
+
+    @Query("SELECT uc.certificationType FROM UserCertification uc WHERE uc.userCertificationId.userId = :userId")
+    List<Integer> findUserCertificationTypeByUserId(Long userId);
+
+    @Query("SELECT uc FROM UserCertification uc WHERE uc.userCertificationId.userId = :userId")
+    List<UserCertification> findUserCertificationByUserId(Long userId);
+
+    void deleteByExpirationDateLessThanEqual(LocalDateTime nowDate);
+
+}

--- a/api/src/main/java/com/thesurvey/api/service/UserCertificationService.java
+++ b/api/src/main/java/com/thesurvey/api/service/UserCertificationService.java
@@ -1,0 +1,101 @@
+package com.thesurvey.api.service;
+
+import com.thesurvey.api.domain.EnumTypeEntity.CertificationType;
+import com.thesurvey.api.domain.User;
+import com.thesurvey.api.domain.UserCertification;
+import com.thesurvey.api.dto.request.user.UserCertificationUpdateRequestDto;
+import com.thesurvey.api.dto.response.userCertification.UserCertificationListDto;
+import com.thesurvey.api.repository.UserCertificationRepository;
+import com.thesurvey.api.service.mapper.UserCertificationMapper;
+import com.thesurvey.api.util.UserUtil;
+
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.util.List;
+
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.security.core.Authentication;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+public class UserCertificationService {
+
+    private final UserCertificationRepository userCertificationRepository;
+
+    private final UserCertificationMapper userCertificationMapper;
+
+    public UserCertificationService(UserCertificationRepository userCertificationRepository,
+        UserCertificationMapper userCertificationMapper) {
+        this.userCertificationRepository = userCertificationRepository;
+        this.userCertificationMapper = userCertificationMapper;
+    }
+
+    @Transactional(readOnly = true)
+    public UserCertificationListDto getUserCertifications(Authentication authentication) {
+        Long userId = UserUtil.getUserIdFromAuthentication(authentication);
+        return userCertificationMapper.toUserCertificationListDto(userId);
+    }
+
+    @Transactional
+    public UserCertificationListDto updateUserCertification(Authentication authentication,
+        UserCertificationUpdateRequestDto userCertificationUpdateRequestDto) {
+        User user = UserUtil.getUserFromAuthentication(authentication);
+        List<Integer> userCertificationList =
+            userCertificationRepository.findUserCertificationTypeByUserId(user.getUserId());
+
+        if (userCertificationUpdateRequestDto.getIsKakaoCertificated()) {
+            saveUserCertification(user, CertificationType.KAKAO, userCertificationList);
+        }
+
+        if (userCertificationUpdateRequestDto.getIsNaverCertificated()) {
+            saveUserCertification(user, CertificationType.NAVER, userCertificationList);
+        }
+
+        if (userCertificationUpdateRequestDto.getIsGoogleCertificated()) {
+            saveUserCertification(user, CertificationType.GOOGLE, userCertificationList);
+        }
+
+        if (userCertificationUpdateRequestDto.getIsWebMailCertificated()) {
+            saveUserCertification(user, CertificationType.WEBMAIL, userCertificationList);
+        }
+
+        if (userCertificationUpdateRequestDto.getIsDriverLicenseCertificated()) {
+            saveUserCertification(user, CertificationType.DRIVER_LICENSE, userCertificationList);
+        }
+
+        if (userCertificationUpdateRequestDto.getIsIdentityCardCertificated()) {
+            saveUserCertification(user, CertificationType.IDENTITY_CARD,
+                userCertificationList);
+        }
+
+        return userCertificationMapper.toUserCertificationListDto(user.getUserId());
+    }
+
+    /**
+     * This method is a scheduled task that runs every day at midnight
+     * (in the "Asia/Seoul" timezone) to delete expired user certifications from the database.
+     */
+    @Scheduled(cron = "0 0 0 * * ?")
+    public void deleteExpiredCertificates() {
+        userCertificationRepository.deleteByExpirationDateLessThanEqual(
+            LocalDateTime.now(ZoneId.of("Asia/Seoul")));
+    }
+
+    private void saveUserCertification(User user, CertificationType certificationType,
+        List<Integer> userCertificationList) {
+        if (!userCertificationList.contains(certificationType.getCertificationTypeId())) {
+            userCertificationRepository.save(buildUserCertification(user, certificationType));
+        }
+    }
+
+    private UserCertification buildUserCertification(User user, CertificationType certificationType) {
+        return UserCertification.builder()
+            .user(user)
+            .certificationType(certificationType)
+            .certificationDate(LocalDateTime.now(ZoneId.of("Asia/Seoul")))
+            // The expiration date is set to 2 years after the current date.
+            .expirationDate(LocalDateTime.now(ZoneId.of("Asia/Seoul")).plusYears(2))
+            .build();
+    }
+}

--- a/api/src/main/java/com/thesurvey/api/service/UserCertificationService.java
+++ b/api/src/main/java/com/thesurvey/api/service/UserCertificationService.java
@@ -65,8 +65,7 @@ public class UserCertificationService {
         }
 
         if (userCertificationUpdateRequestDto.getIsIdentityCardCertificated()) {
-            saveUserCertification(user, CertificationType.IDENTITY_CARD,
-                userCertificationList);
+            saveUserCertification(user, CertificationType.IDENTITY_CARD, userCertificationList);
         }
 
         return userCertificationMapper.toUserCertificationListDto(user.getUserId());

--- a/api/src/main/java/com/thesurvey/api/service/mapper/UserCertificationMapper.java
+++ b/api/src/main/java/com/thesurvey/api/service/mapper/UserCertificationMapper.java
@@ -1,0 +1,125 @@
+package com.thesurvey.api.service.mapper;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import com.thesurvey.api.domain.EnumTypeEntity.CertificationType;
+import com.thesurvey.api.domain.UserCertification;
+import com.thesurvey.api.dto.response.userCertification.DriverLicenseCertificationInfoDto;
+import com.thesurvey.api.dto.response.userCertification.GoogleCertificationInfoDto;
+import com.thesurvey.api.dto.response.userCertification.IdentityCardCertificationInfoDto;
+import com.thesurvey.api.dto.response.userCertification.KakaoCertificationInfoDto;
+import com.thesurvey.api.dto.response.userCertification.NaverCertificationInfoDto;
+import com.thesurvey.api.dto.response.userCertification.UserCertificationListDto;
+import com.thesurvey.api.dto.response.userCertification.WebMailCertificationInfoDto;
+import com.thesurvey.api.repository.UserCertificationRepository;
+
+import org.springframework.stereotype.Component;
+
+@Component
+public class UserCertificationMapper {
+
+    private final UserCertificationRepository userCertificationRepository;
+
+    public UserCertificationMapper(UserCertificationRepository userCertificationRepository) {
+        this.userCertificationRepository = userCertificationRepository;
+    }
+
+    public UserCertificationListDto toUserCertificationListDto(Long userId) {
+        List<UserCertification> userCertificationList =
+            userCertificationRepository.findUserCertificationByUserId(userId);
+
+        UserCertificationListDto userCertificationListDto = new UserCertificationListDto();
+        for (UserCertification userCertification : userCertificationList) {
+            CertificationType certificationType = userCertification.getCertificationType();
+            setCertificationInfo(userCertificationListDto, userCertification, certificationType);
+        }
+        return userCertificationListDto;
+    }
+
+    public void setCertificationInfo(UserCertificationListDto userCertificationListDto,
+        UserCertification userCertification,
+        CertificationType certificationType) {
+        LocalDateTime expirationDate = userCertification.getExpirationDate();
+        switch (certificationType) {
+            case KAKAO:
+                userCertificationListDto.setKakaoCertificationInfo(
+                    buildKakaoCertificationInfoDto(expirationDate)
+                );
+                break;
+
+            case NAVER:
+                userCertificationListDto.setNaverCertificationInfo(
+                    buildNaverCertificationInfoDto(expirationDate)
+                );
+                break;
+
+            case GOOGLE:
+                userCertificationListDto.setGoogleCertificationInfo(
+                    buildGoogleCertificationInfoDto(expirationDate)
+                );
+                break;
+
+            case WEBMAIL:
+                userCertificationListDto.setWebMailCertificationInfo(
+                    buildWebMailCertificationInfoDto(expirationDate)
+                );
+                break;
+
+            case DRIVER_LICENSE:
+                userCertificationListDto.setDriverLicenseCertificationInfo(
+                    buildDriverLicenseCertificationInfoDto(expirationDate)
+                );
+                break;
+
+            case IDENTITY_CARD:
+                userCertificationListDto.setIdentityCardCertificationInfo(
+                    buildIdentityCardCertificationInfoDto(expirationDate)
+                );
+                break;
+        }
+    }
+
+    private KakaoCertificationInfoDto buildKakaoCertificationInfoDto(LocalDateTime expirationDate) {
+        return KakaoCertificationInfoDto.builder()
+            .isCertificated(true)
+            .expirationDate(expirationDate)
+            .build();
+    }
+
+    private NaverCertificationInfoDto buildNaverCertificationInfoDto(LocalDateTime expirationDate) {
+        return NaverCertificationInfoDto.builder()
+            .isCertificated(true)
+            .expirationDate(expirationDate)
+            .build();
+    }
+
+    private GoogleCertificationInfoDto buildGoogleCertificationInfoDto(LocalDateTime expirationDate) {
+        return GoogleCertificationInfoDto.builder()
+            .isCertificated(true)
+            .expirationDate(expirationDate)
+            .build();
+    }
+
+    private WebMailCertificationInfoDto buildWebMailCertificationInfoDto(LocalDateTime expirationDate) {
+        return WebMailCertificationInfoDto.builder()
+            .isCertificated(true)
+            .expirationDate(expirationDate)
+            .build();
+    }
+
+    private DriverLicenseCertificationInfoDto buildDriverLicenseCertificationInfoDto(LocalDateTime expirationDate) {
+        return DriverLicenseCertificationInfoDto.builder()
+            .isCertificated(true)
+            .expirationDate(expirationDate)
+            .build();
+    }
+
+    private IdentityCardCertificationInfoDto buildIdentityCardCertificationInfoDto(LocalDateTime expirationDate) {
+        return IdentityCardCertificationInfoDto.builder()
+            .isCertificated(true)
+            .expirationDate(expirationDate)
+            .build();
+    }
+
+}

--- a/api/src/test/java/com/thesurvey/api/controller/SurveyControllerTest.java
+++ b/api/src/test/java/com/thesurvey/api/controller/SurveyControllerTest.java
@@ -1,49 +1,34 @@
 package com.thesurvey.api.controller;
 
-import com.thesurvey.api.dto.request.user.UserCertificationUpdateRequestDto;
-
-import java.time.LocalDateTime;
-import java.time.ZoneId;
-import java.time.format.DateTimeFormatter;
-import java.util.List;
-import java.util.UUID;
-
 import com.thesurvey.api.domain.AnsweredQuestion;
-import com.thesurvey.api.dto.request.answeredQuestion.AnsweredQuestionDto;
-import com.thesurvey.api.dto.request.answeredQuestion.AnsweredQuestionRequestDto;
-import com.thesurvey.api.service.AnsweredQuestionService;
 import com.thesurvey.api.domain.EnumTypeEntity.CertificationType;
 import com.thesurvey.api.domain.EnumTypeEntity.QuestionType;
+import com.thesurvey.api.dto.request.answeredQuestion.AnsweredQuestionDto;
+import com.thesurvey.api.dto.request.answeredQuestion.AnsweredQuestionRequestDto;
 import com.thesurvey.api.dto.request.question.QuestionBankUpdateRequestDto;
 import com.thesurvey.api.dto.request.question.QuestionOptionRequestDto;
 import com.thesurvey.api.dto.request.question.QuestionOptionUpdateRequestDto;
 import com.thesurvey.api.dto.request.question.QuestionRequestDto;
 import com.thesurvey.api.dto.request.survey.SurveyRequestDto;
 import com.thesurvey.api.dto.request.survey.SurveyUpdateRequestDto;
+import com.thesurvey.api.dto.request.user.UserCertificationUpdateRequestDto;
 import com.thesurvey.api.dto.request.user.UserLoginRequestDto;
 import com.thesurvey.api.dto.request.user.UserRegisterRequestDto;
-import com.thesurvey.api.repository.ParticipationRepository;
-import com.thesurvey.api.repository.QuestionBankRepository;
-import com.thesurvey.api.repository.QuestionOptionRepository;
-import com.thesurvey.api.repository.QuestionRepository;
-import com.thesurvey.api.repository.SurveyRepository;
-import com.thesurvey.api.repository.UserRepository;
+import com.thesurvey.api.repository.*;
+import com.thesurvey.api.service.AnsweredQuestionService;
 import com.thesurvey.api.service.AuthenticationService;
 import com.thesurvey.api.service.SurveyService;
 import com.thesurvey.api.service.mapper.QuestionBankMapper;
 import com.thesurvey.api.service.mapper.QuestionMapper;
 import com.thesurvey.api.service.mapper.SurveyMapper;
 import com.thesurvey.api.util.UserUtil;
-
 import org.json.JSONArray;
 import org.json.JSONObject;
-
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.TestInstance.Lifecycle;
-
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -56,12 +41,15 @@ import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.web.servlet.MvcResult;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
+import java.util.List;
+import java.util.UUID;
+
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.authentication;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @SpringBootTest
@@ -260,7 +248,7 @@ public class SurveyControllerTest extends BaseControllerTest {
             .isIdentityCardCertificated(true)
             .build();
 
-        mockMvc.perform(patch("/users/profile/authentications")
+        mockMvc.perform(patch("/users/profile/certifications")
                 .with(authentication(authentication))
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(objectMapper.writeValueAsString(userCertificationUpdateRequestDto)))

--- a/api/src/test/java/com/thesurvey/api/controller/SurveyControllerTest.java
+++ b/api/src/test/java/com/thesurvey/api/controller/SurveyControllerTest.java
@@ -1,5 +1,7 @@
 package com.thesurvey.api.controller;
 
+import com.thesurvey.api.dto.request.user.UserCertificationUpdateRequestDto;
+
 import java.time.LocalDateTime;
 import java.time.ZoneId;
 import java.time.format.DateTimeFormatter;
@@ -246,9 +248,23 @@ public class SurveyControllerTest extends BaseControllerTest {
             .build();
         AnsweredQuestionRequestDto answeredQuestionRequestDto = AnsweredQuestionRequestDto.builder()
             .surveyId(UUID.fromString(mockSurvey.get("surveyId").toString()))
-            .certificationTypes(List.of(CertificationType.GOOGLE))
             .answers(List.of(answeredQuestionDto))
             .build();
+
+        UserCertificationUpdateRequestDto userCertificationUpdateRequestDto = UserCertificationUpdateRequestDto.builder()
+            .isKakaoCertificated(true)
+            .isNaverCertificated(true)
+            .isGoogleCertificated(true)
+            .isWebMailCertificated(true)
+            .isDriverLicenseCertificated(true)
+            .isIdentityCardCertificated(true)
+            .build();
+
+        mockMvc.perform(patch("/users/profile/authentications")
+                .with(authentication(authentication))
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(userCertificationUpdateRequestDto)))
+            .andExpect(status().isOk());
 
         // when
         mockMvc.perform(post("/surveys/submit")

--- a/api/src/test/java/com/thesurvey/api/controller/UserControllerTest.java
+++ b/api/src/test/java/com/thesurvey/api/controller/UserControllerTest.java
@@ -129,12 +129,12 @@ public class UserControllerTest extends BaseControllerTest {
 
         // then
         JSONObject content = new JSONObject(result.getResponse().getContentAsString());
-        assertThat(content.isNull("kakaoCertificationInfo")).isFalse();
-        assertThat(content.isNull("naverCertificationInfo")).isFalse();
+        assertThat(content.isNull("kakaoCertificationInfo")).isFalse(); // completed certification
+        assertThat(content.isNull("naverCertificationInfo")).isFalse(); // completed certification
         assertThat(content.isNull("googleCertificationInfo")).isTrue();
-        assertThat(content.isNull("webMailCertificationInfo")).isFalse();
+        assertThat(content.isNull("webMailCertificationInfo")).isFalse(); // completed certification
         assertThat(content.isNull("driverLicenseCertificationInfo")).isTrue();
-        assertThat(content.isNull("identityCardCertificationInfo")).isFalse();
+        assertThat(content.isNull("identityCardCertificationInfo")).isFalse(); // completed certification
     }
 
     @Test

--- a/api/src/test/java/com/thesurvey/api/controller/UserControllerTest.java
+++ b/api/src/test/java/com/thesurvey/api/controller/UserControllerTest.java
@@ -16,12 +16,6 @@ import com.thesurvey.api.repository.UserRepository;
 import com.thesurvey.api.service.AuthenticationService;
 import com.thesurvey.api.service.UserService;
 import com.thesurvey.api.util.UserUtil;
-
-import java.time.LocalDateTime;
-import java.time.ZoneId;
-import java.util.List;
-import java.util.UUID;
-
 import org.json.JSONArray;
 import org.json.JSONObject;
 import org.junit.jupiter.api.BeforeAll;
@@ -29,7 +23,6 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.TestInstance.Lifecycle;
-
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -40,12 +33,14 @@ import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.web.servlet.MvcResult;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.util.List;
+import java.util.UUID;
+
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.authentication;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @SpringBootTest
@@ -93,7 +88,7 @@ public class UserControllerTest extends BaseControllerTest {
 
     @Test
     void testGetUserCertifications() throws Exception {
-        MvcResult result = mockMvc.perform(get("/users/profile/auth-list")
+        MvcResult result = mockMvc.perform(get("/users/profile/certifications")
                 .with(authentication(authentication)))
             .andExpect(status().isOk())
             .andReturn();
@@ -120,7 +115,7 @@ public class UserControllerTest extends BaseControllerTest {
             .build();
 
         // when
-        MvcResult result = mockMvc.perform(patch("/users/profile/authentications")
+        MvcResult result = mockMvc.perform(patch("/users/profile/certifications")
                 .with(authentication(authentication))
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(objectMapper.writeValueAsString(userCertificationUpdateRequestDto)))
@@ -252,7 +247,7 @@ public class UserControllerTest extends BaseControllerTest {
             .isIdentityCardCertificated(true)
             .build();
 
-        mockMvc.perform(patch("/users/profile/authentications")
+        mockMvc.perform(patch("/users/profile/certifications")
                 .with(authentication(submitUserAuthentication))
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(objectMapper.writeValueAsString(userCertificationUpdateRequestDto)))

--- a/api/src/test/java/com/thesurvey/api/controller/UserControllerTest.java
+++ b/api/src/test/java/com/thesurvey/api/controller/UserControllerTest.java
@@ -8,6 +8,7 @@ import com.thesurvey.api.dto.request.answeredQuestion.AnsweredQuestionRequestDto
 import com.thesurvey.api.dto.request.question.QuestionOptionRequestDto;
 import com.thesurvey.api.dto.request.question.QuestionRequestDto;
 import com.thesurvey.api.dto.request.survey.SurveyRequestDto;
+import com.thesurvey.api.dto.request.user.UserCertificationUpdateRequestDto;
 import com.thesurvey.api.dto.request.user.UserLoginRequestDto;
 import com.thesurvey.api.dto.request.user.UserRegisterRequestDto;
 import com.thesurvey.api.dto.request.user.UserUpdateRequestDto;
@@ -88,6 +89,52 @@ public class UserControllerTest extends BaseControllerTest {
             new UsernamePasswordAuthenticationToken(userLoginRequestDto.getEmail(),
                 userLoginRequestDto.getPassword())
         );
+    }
+
+    @Test
+    void testGetUserCertifications() throws Exception {
+        MvcResult result = mockMvc.perform(get("/users/profile/auth-list")
+                .with(authentication(authentication)))
+            .andExpect(status().isOk())
+            .andReturn();
+        JSONObject content = new JSONObject(result.getResponse().getContentAsString());
+
+        assertThat(content.isNull("kakaoCertificationInfo")).isTrue();
+        assertThat(content.isNull("naverCertificationInfo")).isTrue();
+        assertThat(content.isNull("googleCertificationInfo")).isTrue();
+        assertThat(content.isNull("webMailCertificationInfo")).isTrue();
+        assertThat(content.isNull("driverLicenseCertificationInfo")).isTrue();
+        assertThat(content.isNull("identityCardCertificationInfo")).isTrue();
+    }
+
+    @Test
+    void testUpdateUserCertifications() throws Exception {
+        // given
+        UserCertificationUpdateRequestDto userCertificationUpdateRequestDto = UserCertificationUpdateRequestDto.builder()
+            .isKakaoCertificated(true)
+            .isNaverCertificated(true)
+            .isGoogleCertificated(false)
+            .isWebMailCertificated(true)
+            .isDriverLicenseCertificated(false)
+            .isIdentityCardCertificated(true)
+            .build();
+
+        // when
+        MvcResult result = mockMvc.perform(patch("/users/profile/authentications")
+                .with(authentication(authentication))
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(userCertificationUpdateRequestDto)))
+            .andExpect(status().isOk())
+            .andReturn();
+
+        // then
+        JSONObject content = new JSONObject(result.getResponse().getContentAsString());
+        assertThat(content.isNull("kakaoCertificationInfo")).isFalse();
+        assertThat(content.isNull("naverCertificationInfo")).isFalse();
+        assertThat(content.isNull("googleCertificationInfo")).isTrue();
+        assertThat(content.isNull("webMailCertificationInfo")).isFalse();
+        assertThat(content.isNull("driverLicenseCertificationInfo")).isTrue();
+        assertThat(content.isNull("identityCardCertificationInfo")).isFalse();
     }
 
     @Test
@@ -188,7 +235,6 @@ public class UserControllerTest extends BaseControllerTest {
 
         AnsweredQuestionRequestDto answeredQuestionRequestDto = AnsweredQuestionRequestDto.builder()
             .surveyId(UUID.fromString(createdSurveyContent.get("surveyId").toString()))
-            .certificationTypes(List.of(CertificationType.GOOGLE))
             .answers(List.of(answeredQuestionDto))
             .build();
 
@@ -196,6 +242,22 @@ public class UserControllerTest extends BaseControllerTest {
             new UsernamePasswordAuthenticationToken(submitAnswerUserLoginRequestDto.getEmail(),
                 submitAnswerUserLoginRequestDto.getPassword())
         );
+
+        UserCertificationUpdateRequestDto userCertificationUpdateRequestDto = UserCertificationUpdateRequestDto.builder()
+            .isKakaoCertificated(true)
+            .isNaverCertificated(true)
+            .isGoogleCertificated(true)
+            .isWebMailCertificated(true)
+            .isDriverLicenseCertificated(false)
+            .isIdentityCardCertificated(true)
+            .build();
+
+        mockMvc.perform(patch("/users/profile/authentications")
+                .with(authentication(submitUserAuthentication))
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(userCertificationUpdateRequestDto)))
+            .andExpect(status().isOk());
+
         mockMvc.perform(post("/surveys/submit")
                 .with(authentication(submitUserAuthentication))
                 .contentType(MediaType.APPLICATION_JSON)

--- a/api/src/test/java/com/thesurvey/api/service/UserCertificationServiceTest.java
+++ b/api/src/test/java/com/thesurvey/api/service/UserCertificationServiceTest.java
@@ -1,0 +1,70 @@
+package com.thesurvey.api.service;
+
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.util.ArrayList;
+
+import com.thesurvey.api.domain.EnumTypeEntity.CertificationType;
+import com.thesurvey.api.domain.User;
+import com.thesurvey.api.domain.UserCertification;
+import com.thesurvey.api.dto.request.user.UserRegisterRequestDto;
+import com.thesurvey.api.repository.UserCertificationRepository;
+import com.thesurvey.api.repository.UserRepository;
+import com.thesurvey.api.service.mapper.UserMapper;
+import org.junit.jupiter.api.Test;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+@SpringBootTest
+@Transactional
+public class UserCertificationServiceTest {
+
+    @Autowired
+    UserCertificationService userCertificationService;
+
+    @Autowired
+    UserCertificationRepository userCertificationRepository;
+
+    @Autowired
+    UserRepository userRepository;
+
+    @Autowired
+    UserMapper userMapper;
+
+    @Test
+    void testDeleteExpiredCertificates() {
+        // given
+        UserRegisterRequestDto userRegisterRequestDto = UserRegisterRequestDto.builder()
+            .name("certificationUser")
+            .email("userCertification@gmail.com")
+            .password("Password40@")
+            .phoneNumber("01012345678")
+            .build();
+        User user = userMapper.toUser(userRegisterRequestDto);
+        User savedUser = userRepository.save(user);
+
+        // Create a user certification with an expiration date that is 2 years before the current date;
+        LocalDateTime expirationDate = LocalDateTime.now(ZoneId.of("Asia/Seoul")).minusYears(2);
+        UserCertification testUserCertification = UserCertification.builder()
+            .user(savedUser)
+            .certificationDate(LocalDateTime.now(ZoneId.of("Asia/Seoul")).minusYears(3))
+            .expirationDate(expirationDate)
+            .certificationType(CertificationType.KAKAO)
+            .build();
+        userCertificationRepository.save(testUserCertification);
+
+        // when
+        userCertificationRepository.deleteByExpirationDateLessThanEqual(
+            LocalDateTime.now(ZoneId.of("Asia/Seoul")));
+
+        // then
+        assertEquals(userCertificationRepository.
+            findUserCertificationByUserId(savedUser.getUserId()), new ArrayList<>());
+    }
+
+}
+

--- a/api/src/test/java/com/thesurvey/api/service/UserCertificationServiceTest.java
+++ b/api/src/test/java/com/thesurvey/api/service/UserCertificationServiceTest.java
@@ -51,7 +51,7 @@ public class UserCertificationServiceTest {
         LocalDateTime expirationDate = LocalDateTime.now(ZoneId.of("Asia/Seoul")).minusYears(2);
         UserCertification testUserCertification = UserCertification.builder()
             .user(savedUser)
-            .certificationDate(LocalDateTime.now(ZoneId.of("Asia/Seoul")).minusYears(3))
+            .certificationDate(LocalDateTime.now(ZoneId.of("Asia/Seoul")).minusYears(4))
             .expirationDate(expirationDate)
             .certificationType(CertificationType.KAKAO)
             .build();


### PR DESCRIPTION
#130 이슈를 수행하였습니다.
### 개요
`UserCertification`은 사용자의 인증 정보를 저장합니다.
인증 정보엔 인증 여부, 인증을 받은 날짜, 인증 만료 날짜가 포함됩니다.
사용자는 이미 인증된 정보를 요청을 통해 삭제할 수 없습니다.

**추가 사항**
- `UserCertification` Entity, Service, 관련 DTO, Repository 클래스 추가
- `UserCertification` `GET`, `UPDATE` 구현
- 사용자가 설문조사 참여를 위한 인증을 수행하였는지 유효성 검증 로직 추가
- 인증 관련 테스트 코드 추가

**삭제 사항**
- 설문조사 응답 제출 요청을 할 때 인증 정보를 포함할 필요가 없어 `AnswerQuestionRequestDto` 에서 `certificationTypes` 필드를 삭제하였습니다. 대신 사용자의 인증 정보와 설문조사 응답에 필요한 인증 정보를 비교하는 로직을 추가하였습니다. (#153 이슈를 해결합니다.)

**API 명세**
- 사용자의 인증 목록 요청: `GET /users/profile/certifications `
- 사용자의 인증 업데이트 요청: `PATCH /users/profile/certifications `

**JSON Format:**
`com/thesurvey/api/dto/request/user/UserCertificationUpdateRequestDto`
```
{
    "isKakaoCertificated": true,
    "isNaverCertificated": true,
    "isGoogleCertificated": false,
    "isWebMailCertificated": true,
    "isDriverLicenseCertificated": false,
    "isIdentityCardCertificated": true
}
```

`com/thesurvey/api/dto/response/user/UserCertificationListDto`
```
{
    "kakaoCertificationInfo": {
        "isCertificated": true,
        "expirationDate": "2025-05-12T20:20:16"
    },
    "naverCertificationInfo": {
        "isCertificated": true,
        "expirationDate": "2025-05-12T20:20:16"
    },
    "googleCertificationInfo": null,
    "webMailCertificationInfo": {
        "isCertificated": true,
        "expirationDate": "2025-05-12T20:20:16"
    },
    "driverLicenseCertificationInfo": null,
    "identityCardCertificationInfo": {
        "isCertificated": true,
        "expirationDate": "2025-05-12T20:20:16"
    }
}
```