### PR TITLE
fix: 개별 설문조사 조회 API에서 json 데이터 중`questions`가 항상 null로 리턴하는 문제 해결

### DIFF
--- a/api/src/main/java/com/thesurvey/api/service/SurveyService.java
+++ b/api/src/main/java/com/thesurvey/api/service/SurveyService.java
@@ -77,7 +77,7 @@ public class SurveyService {
     public SurveyResponseDto getSurveyBySurveyIdWithRelatedQuestion(UUID surveyId) {
         Survey survey = surveyRepository.findBySurveyId(surveyId)
             .orElseThrow(() -> new NotFoundExceptionMapper(ErrorMessage.SURVEY_NOT_FOUND));
-        return surveyMapper.toSurveyResponseDto(survey);
+        return surveyMapper.toSurveyResponseDto(survey, survey.getAuthorId());
     }
 
     @Transactional(readOnly = true)

--- a/api/src/main/java/com/thesurvey/api/service/mapper/SurveyMapper.java
+++ b/api/src/main/java/com/thesurvey/api/service/mapper/SurveyMapper.java
@@ -32,21 +32,6 @@ public class SurveyMapper {
         this.certificationTypeConverter = certificationTypeConverter;
     }
 
-    public SurveyResponseDto toSurveyResponseDto(Survey survey) {
-        return SurveyResponseDto.builder()
-            .surveyId(survey.getSurveyId())
-            .authorId(survey.getAuthorId())
-            .title(survey.getTitle())
-            .description(survey.getDescription())
-            .startedDate(survey.getStartedDate())
-            .endedDate(survey.getEndedDate())
-            .createdDate(survey.getCreatedDate())
-            .modifiedDate(survey.getModifiedDate())
-            .certificationTypes(certificationTypeConverter.toCertificationTypeList(
-                surveyRepository.findCertificationTypeBySurveyId(survey.getSurveyId())))
-            .build();
-    }
-
     public SurveyResponseDto toSurveyResponseDto(Survey survey, Long authorId) {
         List<QuestionBankResponseDto> questionBankResponseDtoList = questionService.getQuestionBankInfoDtoListBySurveyId(
             survey.getSurveyId());

--- a/api/src/test/java/com/thesurvey/api/controller/SurveyControllerTest.java
+++ b/api/src/test/java/com/thesurvey/api/controller/SurveyControllerTest.java
@@ -195,6 +195,7 @@ public class SurveyControllerTest extends BaseControllerTest {
             .isEqualTo(content.getString("endedDate"));
         assertThat(LocalDateTime.parse(content.getString("startedDate"))).isBefore(
             LocalDateTime.parse(content.getString("endedDate")));
+        assertThat(content.getJSONArray("questions")).isNotNull();
     }
 
     @Test


### PR DESCRIPTION
이슈 해결 #138 

**수정 내역**
- SurveyMapper.java 에서 toSurveyResponseDto 메소드 중 questions 를 할당하지 않는 메소드 제거