### PR TITLE
refactor: 각 repository 메소드에 `Optional` 클래스 추가

### DIFF
--- a/api/src/main/java/com/thesurvey/api/exception/ErrorMessage.java
+++ b/api/src/main/java/com/thesurvey/api/exception/ErrorMessage.java
@@ -26,7 +26,10 @@ public enum ErrorMessage {
     NOT_SURVEY_QUESTION("해당 설문조사의 질문이 아닙니다."),
     INVALID_REQUEST("유효하지 않은 요청입니다"),
     PAGE_NOT_FOUND("존재하지 않는 페이지입니다."),
-    USER_CREATED_SURVEY_NOT_FOUND("생성한 설문조사가 없습니다.");
+    USER_CREATED_SURVEY_NOT_FOUND("생성한 설문조사가 없습니다."),
+    CERTIFICATION_NOT_FOUND("인증 정보를 찾을 수 없습니다."),
+    PARTICIPATION_NOT_FOUND("설문 참여 정보를 찾을 수 없습니다."),
+    ANSWERED_QUESTION_NOT_FOUND("설문 응답 정보를 찾을 수 없습니다.");
 
     private final String message;
 

--- a/api/src/main/java/com/thesurvey/api/exception/ErrorMessage.java
+++ b/api/src/main/java/com/thesurvey/api/exception/ErrorMessage.java
@@ -28,8 +28,8 @@ public enum ErrorMessage {
     PAGE_NOT_FOUND("존재하지 않는 페이지입니다."),
     USER_CREATED_SURVEY_NOT_FOUND("생성한 설문조사가 없습니다."),
     CERTIFICATION_NOT_FOUND("인증 정보를 찾을 수 없습니다."),
-    PARTICIPATION_NOT_FOUND("설문 참여 정보를 찾을 수 없습니다."),
-    ANSWERED_QUESTION_NOT_FOUND("설문 응답 정보를 찾을 수 없습니다.");
+    PARTICIPATION_NOT_FOUND("설문조사 참여 정보를 찾을 수 없습니다."),
+    ANSWERED_QUESTION_NOT_FOUND("설문조사 응답 정보를 찾을 수 없습니다.");
 
     private final String message;
 

--- a/api/src/main/java/com/thesurvey/api/repository/AnsweredQuestionRepository.java
+++ b/api/src/main/java/com/thesurvey/api/repository/AnsweredQuestionRepository.java
@@ -15,10 +15,10 @@ import org.springframework.stereotype.Repository;
 public interface AnsweredQuestionRepository extends
     JpaRepository<AnsweredQuestion, AnsweredQuestionId> {
     @Query("SELECT aq FROM AnsweredQuestion aq WHERE aq.answeredQuestionId.surveyId = :surveyId")
-    List<AnsweredQuestion> findAllBySurveyId(UUID surveyId);
+    Optional<List<AnsweredQuestion>> findAllBySurveyId(UUID surveyId);
 
     @Query("SELECT aq FROM AnsweredQuestion aq WHERE aq.answeredQuestionId.questionBankId = :questionBankId")
-    List<AnsweredQuestion> findAllByQuestionBankId(Long questionBankId);
+    Optional<List<AnsweredQuestion>> findAllByQuestionBankId(Long questionBankId);
 
     @Query("SELECT CASE WHEN COUNT(aq) > 0 THEN true ELSE false END FROM AnsweredQuestion aq WHERE aq.answeredQuestionId.userId = :userId AND aq.answeredQuestionId.surveyId = :surveyId")
     boolean existsByUserIdAndSurveyId(Long userId, UUID surveyId);

--- a/api/src/main/java/com/thesurvey/api/repository/ParticipationRepository.java
+++ b/api/src/main/java/com/thesurvey/api/repository/ParticipationRepository.java
@@ -1,6 +1,7 @@
 package com.thesurvey.api.repository;
 
 import java.util.List;
+import java.util.Optional;
 import java.util.UUID;
 
 import com.thesurvey.api.domain.Participation;
@@ -14,8 +15,6 @@ import org.springframework.stereotype.Repository;
 public interface ParticipationRepository extends JpaRepository<Participation, ParticipationId> {
 
     @Query("SELECT p FROM Participation p WHERE p.survey.surveyId = :surveyId")
-    List<Participation> findAllBySurveyId(UUID surveyId);
+    Optional<List<Participation>> findAllBySurveyId(UUID surveyId);
 
-    @Query("SELECT CASE WHEN COUNT(p) > 0 THEN true ELSE false END FROM Participation p WHERE p.user.userId = :userId AND p.survey.surveyId = :surveyId")
-    boolean existsByUserIdAndSurveyId(Long userId, UUID surveyId);
 }

--- a/api/src/main/java/com/thesurvey/api/repository/QuestionBankRepository.java
+++ b/api/src/main/java/com/thesurvey/api/repository/QuestionBankRepository.java
@@ -16,9 +16,6 @@ public interface QuestionBankRepository extends JpaRepository<QuestionBank, Long
     Optional<QuestionBank> findByQuestionBankId(Long questionBankId);
 
     @Query("SELECT qb FROM QuestionBank qb JOIN FETCH qb.questions q JOIN q.survey s WHERE q.questionId.surveyId= :surveyId")
-    List<QuestionBank> findAllBySurveyId(UUID surveyId);
-
-    @Query("SELECT qb FROM QuestionBank qb JOIN FETCH qb.questions q JOIN q.survey s WHERE q.questionId.surveyId = :surveyId AND qb.title = :title")
-    Optional<QuestionBank> findBySurveyIdAndTitle(UUID surveyId, String title);
+    Optional<List<QuestionBank>> findAllBySurveyId(UUID surveyId);
 
 }

--- a/api/src/main/java/com/thesurvey/api/repository/QuestionRepository.java
+++ b/api/src/main/java/com/thesurvey/api/repository/QuestionRepository.java
@@ -15,7 +15,7 @@ import org.springframework.stereotype.Repository;
 public interface QuestionRepository extends JpaRepository<Question, QuestionId> {
 
     @Query("SELECT q FROM Question q WHERE q.survey.surveyId = :surveyId ORDER BY q.questionNo ASC")
-    List<Question> findAllBySurveyId(UUID surveyId);
+    Optional<List<Question>> findAllBySurveyId(UUID surveyId);
 
     @Query("SELECT q.questionNo FROM Question q WHERE q.questionBank.questionBankId = :questionBankId")
     Optional<Integer> findQuestionNoByQuestionBankId(Long questionBankId);

--- a/api/src/main/java/com/thesurvey/api/repository/SurveyRepository.java
+++ b/api/src/main/java/com/thesurvey/api/repository/SurveyRepository.java
@@ -1,17 +1,16 @@
 package com.thesurvey.api.repository;
 
+import com.thesurvey.api.domain.Survey;
+import com.thesurvey.api.dto.response.user.UserSurveyTitleDto;
+
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
-
-import com.thesurvey.api.domain.Survey;
-import com.thesurvey.api.dto.response.user.UserSurveyTitleDto;
 
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
-import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 @Repository
@@ -20,12 +19,12 @@ public interface SurveyRepository extends JpaRepository<Survey, UUID> {
     @Query("SELECT s FROM Survey s ORDER BY s.createdDate DESC")
     Page<Survey> findAllInDescendingOrder(Pageable pageable);
 
-    @Query("SELECT p.certificationType FROM Participation p WHERE p.survey.surveyId = :survey_id")
-    List<Integer> findCertificationTypeBySurveyId(@Param("survey_id") UUID surveyId);
+    @Query("SELECT p.certificationType FROM Participation p WHERE p.survey.surveyId = :surveyId")
+    Optional<List<Integer>> findCertificationTypeBySurveyId(UUID surveyId);
 
     Optional<Survey> findBySurveyId(UUID surveyId);
 
-    @Query("SELECT new com.thesurvey.api.dto.response.user.UserSurveyTitleDto(s.surveyId, s.title) FROM Survey s WHERE s.authorId = :author_id ORDER BY s.createdDate DESC")
-    List<UserSurveyTitleDto> findUserCreatedSurveysByAuthorID(@Param("author_id") Long authorId);
+    @Query("SELECT new com.thesurvey.api.dto.response.user.UserSurveyTitleDto(s.surveyId, s.title) FROM Survey s WHERE s.authorId = :authorId ORDER BY s.createdDate DESC")
+    Optional<List<UserSurveyTitleDto>> findUserCreatedSurveysByAuthorID(Long authorId);
 
 }

--- a/api/src/main/java/com/thesurvey/api/service/AnsweredQuestionService.java
+++ b/api/src/main/java/com/thesurvey/api/service/AnsweredQuestionService.java
@@ -58,7 +58,8 @@ public class AnsweredQuestionService {
 
     @Transactional
     public List<AnsweredQuestion> getAnswerQuestionByQuestionBankId(Long questionBankId) {
-        return answeredQuestionRepository.findAllByQuestionBankId(questionBankId);
+        return answeredQuestionRepository.findAllByQuestionBankId(questionBankId)
+            .orElseThrow(() -> new NotFoundExceptionMapper(ErrorMessage.ANSWERED_QUESTION_NOT_FOUND));
     }
 
     @Transactional(readOnly = true)
@@ -110,7 +111,7 @@ public class AnsweredQuestionService {
 
             // check if the question is included in the survey.
             if (questionRepository.notExistsBySurveyIdAndQuestionBankId(survey.getSurveyId(),
-                questionBank.getQuestionBankId())) {
+                questionBank.getQuestionBankId())){
                 throw new BadRequestExceptionMapper(ErrorMessage.NOT_SURVEY_QUESTION);
             }
 
@@ -138,7 +139,7 @@ public class AnsweredQuestionService {
     @Transactional
     public void deleteAnswer(UUID surveyId) {
         List<AnsweredQuestion> answeredQuestionList = answeredQuestionRepository.findAllBySurveyId(
-            surveyId);
+            surveyId).orElseThrow(() -> new NotFoundExceptionMapper(ErrorMessage.ANSWERED_QUESTION_NOT_FOUND));
         answeredQuestionRepository.deleteAll(answeredQuestionList);
     }
 

--- a/api/src/main/java/com/thesurvey/api/service/ParticipationService.java
+++ b/api/src/main/java/com/thesurvey/api/service/ParticipationService.java
@@ -7,6 +7,8 @@ import com.thesurvey.api.domain.EnumTypeEntity.CertificationType;
 import com.thesurvey.api.domain.Participation;
 import com.thesurvey.api.domain.Survey;
 import com.thesurvey.api.domain.User;
+import com.thesurvey.api.exception.ErrorMessage;
+import com.thesurvey.api.exception.mapper.NotFoundExceptionMapper;
 import com.thesurvey.api.repository.ParticipationRepository;
 import com.thesurvey.api.service.mapper.ParticipationMapper;
 
@@ -37,7 +39,8 @@ public class ParticipationService {
 
     @Transactional
     public void deleteParticipation(UUID surveyId) {
-        List<Participation> participationList = participationRepository.findAllBySurveyId(surveyId);
+        List<Participation> participationList = participationRepository.findAllBySurveyId(surveyId)
+            .orElseThrow(() -> new NotFoundExceptionMapper(ErrorMessage.PARTICIPATION_NOT_FOUND));
         participationRepository.deleteAll(participationList);
     }
 }

--- a/api/src/main/java/com/thesurvey/api/service/QuestionService.java
+++ b/api/src/main/java/com/thesurvey/api/service/QuestionService.java
@@ -3,6 +3,7 @@ package com.thesurvey.api.service;
 import com.thesurvey.api.exception.mapper.NotFoundExceptionMapper;
 
 import java.util.List;
+import java.util.Optional;
 import java.util.UUID;
 import java.util.stream.Collectors;
 
@@ -50,12 +51,17 @@ public class QuestionService {
 
     @Transactional(readOnly = true)
     public List<QuestionBank> getAllQuestionBankBySurveyId(UUID surveyId) {
-        return questionBankRepository.findAllBySurveyId(surveyId);
+        return questionBankRepository.findAllBySurveyId(surveyId).orElseThrow(
+            () -> new NotFoundExceptionMapper(ErrorMessage.QUESTION_NOT_FOUND)
+        );
     }
 
     @Transactional(readOnly = true)
     public List<QuestionBankResponseDto> getQuestionBankInfoDtoListBySurveyId(UUID surveyId) {
-        return questionBankRepository.findAllBySurveyId(surveyId)
+        List<QuestionBank> questionBankList = questionBankRepository.findAllBySurveyId(surveyId).orElseThrow(
+            () -> new NotFoundExceptionMapper(ErrorMessage.QUESTION_NOT_FOUND)
+        );
+        return questionBankList
             .stream()
             .map(questionBankMapper::toQuestionBankResponseDto)
             .collect(Collectors.toList());
@@ -125,8 +131,9 @@ public class QuestionService {
 
     @Transactional
     public void deleteQuestion(UUID surveyId) {
-        List<Question> questionList = questionRepository.findAllBySurveyId(surveyId);
-        questionRepository.deleteAll(questionList);
+        Optional<List<Question>> questionList = questionRepository.findAllBySurveyId(surveyId);
+        questionRepository.deleteAll(questionList.orElseThrow(
+            () -> new NotFoundExceptionMapper(ErrorMessage.QUESTION_NOT_FOUND)));
     }
 
 }

--- a/api/src/main/java/com/thesurvey/api/service/SurveyService.java
+++ b/api/src/main/java/com/thesurvey/api/service/SurveyService.java
@@ -89,7 +89,8 @@ public class SurveyService {
     @Transactional(readOnly = true)
     public List<UserSurveyTitleDto> getUserCreatedSurveys(Authentication authentication) {
         return surveyRepository.findUserCreatedSurveysByAuthorID(
-            UserUtil.getUserIdFromAuthentication(authentication));
+                UserUtil.getUserIdFromAuthentication(authentication))
+            .orElseThrow(() -> new NotFoundExceptionMapper(ErrorMessage.USER_CREATED_SURVEY_NOT_FOUND));
     }
 
     /**

--- a/api/src/main/java/com/thesurvey/api/service/mapper/SurveyMapper.java
+++ b/api/src/main/java/com/thesurvey/api/service/mapper/SurveyMapper.java
@@ -10,6 +10,8 @@ import com.thesurvey.api.dto.response.survey.SurveyPageDto;
 import com.thesurvey.api.dto.response.survey.SurveyResponseDto;
 import com.thesurvey.api.dto.request.survey.SurveyRequestDto;
 import com.thesurvey.api.dto.response.user.UserSurveyResultDto;
+import com.thesurvey.api.exception.ErrorMessage;
+import com.thesurvey.api.exception.mapper.NotFoundExceptionMapper;
 import com.thesurvey.api.repository.SurveyRepository;
 import com.thesurvey.api.service.QuestionService;
 import com.thesurvey.api.service.converter.CertificationTypeConverter;
@@ -34,21 +36,6 @@ public class SurveyMapper {
         this.certificationTypeConverter = certificationTypeConverter;
     }
 
-    public SurveyResponseDto toSurveyResponseDto(Survey survey) {
-        return SurveyResponseDto.builder()
-            .surveyId(survey.getSurveyId())
-            .authorId(survey.getAuthorId())
-            .title(survey.getTitle())
-            .description(survey.getDescription())
-            .startedDate(survey.getStartedDate())
-            .endedDate(survey.getEndedDate())
-            .createdDate(survey.getCreatedDate())
-            .modifiedDate(survey.getModifiedDate())
-            .certificationTypes(certificationTypeConverter.toCertificationTypeList(
-                surveyRepository.findCertificationTypeBySurveyId(survey.getSurveyId())))
-            .build();
-    }
-
     public SurveyResponseDto toSurveyResponseDto(Survey survey, Long authorId) {
         List<QuestionBankResponseDto> questionBankResponseDtoList = questionService.getQuestionBankInfoDtoListBySurveyId(
             survey.getSurveyId());
@@ -63,7 +50,8 @@ public class SurveyMapper {
             .createdDate(survey.getCreatedDate())
             .modifiedDate(survey.getModifiedDate())
             .certificationTypes(certificationTypeConverter.toCertificationTypeList(
-                surveyRepository.findCertificationTypeBySurveyId(survey.getSurveyId())))
+                surveyRepository.findCertificationTypeBySurveyId(survey.getSurveyId())
+                    .orElseThrow(() -> new NotFoundExceptionMapper(ErrorMessage.CERTIFICATION_NOT_FOUND))))
             .questions(questionBankResponseDtoList)
             .build();
     }
@@ -81,7 +69,7 @@ public class SurveyMapper {
 
     public SurveyPageDto toSurveyPageDto(Survey survey) {
         List<Integer> certificationTypes = surveyRepository.findCertificationTypeBySurveyId(
-            survey.getSurveyId());
+            survey.getSurveyId()).orElseThrow(() -> new NotFoundExceptionMapper(ErrorMessage.CERTIFICATION_NOT_FOUND));
         return SurveyPageDto.builder()
             .surveyId(survey.getSurveyId())
             .authorId(survey.getAuthorId())


### PR DESCRIPTION
#149 이슈를 해결합니다.

**추가 사항**
- 각 `Certification`, `Participation`, `AnsweredQuestion`에 대한 `NOT_FOUND` 에러 메세지 추가

**변경 사항**
- repository 메소드 중 `Optional`로 감싸지 않은 메소드들을 감싸도록 하였습니다.
 
- `@Param` 을 사용하여 `@Query` 문 안에서 메소드 파라미터를 매핑하는 메소드가 있었는데,

다른 repository에선 사용하지 않고 메소드 파라미터 이름과 일치시켜서 자바 네이밍 컨벤션을 따르는게 가독성이 더 좋을 것 같아서 지웠습니다.

수정 전
```
 @Query("SELECT new com.thesurvey.api.dto.response.user.UserSurveyTitleDto(s.surveyId, s.title) FROM Survey s WHERE s.authorId = :author_id ORDER BY s.createdDate DESC")
     List<UserSurveyTitleDto> findUserCreatedSurveysByAuthorID(@Param("author_id") Long authorId);
```
수정 후
```
@Query("SELECT new com.thesurvey.api.dto.response.user.UserSurveyTitleDto(s.surveyId, s.title) FROM Survey s WHERE s.authorId = :authorId ORDER BY s.createdDate DESC")
    Optional<List<UserSurveyTitleDto>> findUserCreatedSurveysByAuthorID(Long authorId);
```

- `boolean` 타입을 리턴하는 메소드는 무조건 `true` || `false`를 리턴하기 때문에 `Optional`로 감싸지 않았습니다.