### PR TITLE
fix: 사용자 인증이 필요없는 설문조사 생성시 `participation` 테이블에 정보를 저장하지 않는 문제 해결

### DIFF
--- a/api/src/main/java/com/thesurvey/api/domain/EnumTypeEntity.java
+++ b/api/src/main/java/com/thesurvey/api/domain/EnumTypeEntity.java
@@ -15,22 +15,26 @@ public class EnumTypeEntity {
      * {@link CertificationType} represents various types of certifications
      * that can be used for user certification.
      * The available certification types are
-     * KAKAO, NAVER, GOOGLE, WEBMAIL, DRIVER_LICENSE, IDENTITY_CARD.
+     * NONE, KAKAO, NAVER, GOOGLE, WEBMAIL, DRIVER_LICENSE, IDENTITY_CARD.
+     * The NONE type is used as the certificationType when creating a survey
+     * that do not require user certification.
      * {@code certificationTypeId} is the ID value that is saved in the database.
      */
     public enum CertificationType {
 
-        KAKAO(0),
+        NONE(0),
 
-        NAVER(1),
+        KAKAO(1),
 
-        GOOGLE(2),
+        NAVER(2),
 
-        WEBMAIL(3),
+        GOOGLE(3),
 
-        DRIVER_LICENSE(4),
+        WEBMAIL(4),
 
-        IDENTITY_CARD(5);
+        DRIVER_LICENSE(5),
+
+        IDENTITY_CARD(6);
 
         @Getter
         private final int certificationTypeId;

--- a/api/src/main/java/com/thesurvey/api/domain/ParticipationId.java
+++ b/api/src/main/java/com/thesurvey/api/domain/ParticipationId.java
@@ -21,7 +21,7 @@ public class ParticipationId implements Serializable {
     /*
      * the value of id is set to the index of EnumTypeEntity.CertificationType.
      * the value of id : CertificationType
-     * 0: KAKAO, 1: NAVER, 2: GOOGLE, 3: WEBMAIL, 4: DRIVER_LICENSE, 5: IDENTITY_CARD
+     * 0: NONE, 1: KAKAO, 2: NAVER, 3: GOOGLE, 4: WEBMAIL, 5: DRIVER_LICENSE, 6: IDENTITY_CARD
      */
     @Column(name = "certification_type")
     private CertificationType certificationType;

--- a/api/src/main/java/com/thesurvey/api/service/SurveyService.java
+++ b/api/src/main/java/com/thesurvey/api/service/SurveyService.java
@@ -8,6 +8,7 @@ import java.util.UUID;
 import java.util.stream.Collectors;
 
 import com.thesurvey.api.domain.AnsweredQuestion;
+import com.thesurvey.api.domain.EnumTypeEntity.CertificationType;
 import com.thesurvey.api.domain.EnumTypeEntity.QuestionType;
 import com.thesurvey.api.domain.QuestionBank;
 import com.thesurvey.api.domain.Survey;
@@ -143,12 +144,15 @@ public class SurveyService {
             throw new BadRequestExceptionMapper(ErrorMessage.STARTEDDATE_ISAFTER_ENDEDDATE);
         }
 
+        List<CertificationType> certificationTypes =
+            surveyRequestDto.getCertificationTypes().isEmpty()
+                ? List.of(CertificationType.NONE) : surveyRequestDto.getCertificationTypes();
+
         User user = UserUtil.getUserFromAuthentication(authentication);
         Survey survey = surveyRepository.save(surveyMapper.toSurvey(surveyRequestDto,
             user.getUserId()));
         questionService.createQuestion(surveyRequestDto, survey);
-        participationService.createParticipation(user, surveyRequestDto.getCertificationTypes(),
-            survey);
+        participationService.createParticipation(user, certificationTypes, survey);
         return surveyMapper.toSurveyResponseDto(survey, user.getUserId());
     }
 

--- a/api/src/main/java/com/thesurvey/api/service/converter/CertificationTypeConverter.java
+++ b/api/src/main/java/com/thesurvey/api/service/converter/CertificationTypeConverter.java
@@ -20,17 +20,17 @@ public class CertificationTypeConverter {
         return certificationTypeList.stream()
             .map(type -> {
                 switch (type) {
-                    case 0:
-                        return CertificationType.KAKAO;
                     case 1:
-                        return CertificationType.NAVER;
+                        return CertificationType.KAKAO;
                     case 2:
-                        return CertificationType.GOOGLE;
+                        return CertificationType.NAVER;
                     case 3:
-                        return CertificationType.WEBMAIL;
+                        return CertificationType.GOOGLE;
                     case 4:
-                        return CertificationType.DRIVER_LICENSE;
+                        return CertificationType.WEBMAIL;
                     case 5:
+                        return CertificationType.DRIVER_LICENSE;
+                    case 6:
                         return CertificationType.IDENTITY_CARD;
                     default:
                         return null;

--- a/api/src/main/java/com/thesurvey/api/service/mapper/SurveyMapper.java
+++ b/api/src/main/java/com/thesurvey/api/service/mapper/SurveyMapper.java
@@ -1,5 +1,6 @@
 package com.thesurvey.api.service.mapper;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
 
@@ -111,6 +112,11 @@ public class SurveyMapper {
     }
 
     private List<CertificationType> getConvertedCertificationTypes(UUID surveyId) {
+        List<Integer> certificationTypes =
+            surveyRepository.findCertificationTypeBySurveyId(surveyId);
+        if (certificationTypes.contains(CertificationType.NONE.getCertificationTypeId())) {
+            return new ArrayList<>();
+        }
         return certificationTypeConverter.toCertificationTypeList(
             surveyRepository.findCertificationTypeBySurveyId(surveyId));
     }


### PR DESCRIPTION
#154 이슈를 해결합니다.

**변경 사항**
- `CertificationType` enum 클래스에서 0 번째 index로 `NONE`을 추가하였습니다.
-  `SurveyService.java`에서 `surveyRequestDto`의 `certificationTypes`가 empty일 경우, `certificationTypes`를 빈 리스트로 생성하는 로직을 추가하였습니다.