### PR TITLE
fix: 설문조사 목록 요청 관련 이슈 해결

### DIFF
--- a/api/src/main/java/com/thesurvey/api/repository/SurveyRepository.java
+++ b/api/src/main/java/com/thesurvey/api/repository/SurveyRepository.java
@@ -20,12 +20,12 @@ public interface SurveyRepository extends JpaRepository<Survey, UUID> {
     @Query("SELECT s FROM Survey s ORDER BY s.createdDate DESC")
     Page<Survey> findAllInDescendingOrder(Pageable pageable);
 
-    @Query("SELECT p.certificationType FROM Participation p WHERE p.survey.surveyId = :survey_id")
-    List<Integer> findCertificationTypeBySurveyId(@Param("survey_id") UUID surveyId);
+    @Query("SELECT p.certificationType FROM Participation p WHERE p.survey.surveyId = :surveyId AND p.user.userId = :authorId")
+    List<Integer> findCertificationTypeBySurveyIdAndAuthorId(@Param("surveyId") UUID surveyId, @Param("authorId") Long authorId);
 
     Optional<Survey> findBySurveyId(UUID surveyId);
 
-    @Query("SELECT new com.thesurvey.api.dto.response.user.UserSurveyTitleDto(s.surveyId, s.title) FROM Survey s WHERE s.authorId = :author_id ORDER BY s.createdDate DESC")
-    List<UserSurveyTitleDto> findUserCreatedSurveysByAuthorID(@Param("author_id") Long authorId);
+    @Query("SELECT new com.thesurvey.api.dto.response.user.UserSurveyTitleDto(s.surveyId, s.title) FROM Survey s WHERE s.authorId = :authorId ORDER BY s.createdDate DESC")
+    List<UserSurveyTitleDto> findUserCreatedSurveysByAuthorID(@Param("authorId") Long authorId);
 
 }

--- a/api/src/main/java/com/thesurvey/api/service/mapper/SurveyMapper.java
+++ b/api/src/main/java/com/thesurvey/api/service/mapper/SurveyMapper.java
@@ -37,20 +37,6 @@ public class SurveyMapper {
         this.certificationTypeConverter = certificationTypeConverter;
     }
 
-    public SurveyResponseDto toSurveyResponseDto(Survey survey) {
-        return SurveyResponseDto.builder()
-            .surveyId(survey.getSurveyId())
-            .authorId(survey.getAuthorId())
-            .title(survey.getTitle())
-            .description(survey.getDescription())
-            .startedDate(survey.getStartedDate())
-            .endedDate(survey.getEndedDate())
-            .createdDate(survey.getCreatedDate())
-            .modifiedDate(survey.getModifiedDate())
-            .certificationTypes(getConvertedCertificationTypes(survey.getSurveyId()))
-            .build();
-    }
-
     public SurveyResponseDto toSurveyResponseDto(Survey survey, Long authorId) {
         List<QuestionBankResponseDto> questionBankResponseDtoList = questionService.getQuestionBankInfoDtoListBySurveyId(
             survey.getSurveyId());
@@ -64,7 +50,7 @@ public class SurveyMapper {
             .endedDate(survey.getEndedDate())
             .createdDate(survey.getCreatedDate())
             .modifiedDate(survey.getModifiedDate())
-            .certificationTypes(getConvertedCertificationTypes(survey.getSurveyId()))
+            .certificationTypes(getConvertedCertificationTypes(survey.getSurveyId(), survey.getAuthorId()))
             .questions(questionBankResponseDtoList)
             .build();
     }
@@ -87,8 +73,9 @@ public class SurveyMapper {
             .title(survey.getTitle())
             .description(survey.getDescription())
             .startedDate(survey.getStartedDate())
+            .createdDate(survey.getCreatedDate())
             .endedDate(survey.getEndedDate())
-            .certificationTypes(getConvertedCertificationTypes(survey.getSurveyId()))
+            .certificationTypes(getConvertedCertificationTypes(survey.getSurveyId(), survey.getAuthorId()))
             .modifiedDate(survey.getModifiedDate())
             .build();
     }
@@ -111,14 +98,14 @@ public class SurveyMapper {
             .build();
     }
 
-    private List<CertificationType> getConvertedCertificationTypes(UUID surveyId) {
+    private List<CertificationType> getConvertedCertificationTypes(UUID surveyId, Long authorId) {
         List<Integer> certificationTypes =
-            surveyRepository.findCertificationTypeBySurveyId(surveyId);
+            surveyRepository.findCertificationTypeBySurveyIdAndAuthorId(surveyId, authorId);
         if (certificationTypes.contains(CertificationType.NONE.getCertificationTypeId())) {
             return new ArrayList<>();
         }
         return certificationTypeConverter.toCertificationTypeList(
-            surveyRepository.findCertificationTypeBySurveyId(surveyId));
+            certificationTypes);
     }
 
 }


### PR DESCRIPTION
#157 이슈를 해결합니다.

**수정 사항**
- SurveyMapper 에서 `toSurveyPageDto`에 누락된 `createdDate` 추가
- `Participation` 테이블에서 `surveyId`에 따른 `certificationType`을 불러오는 함수인 `findCertificationTypeBySurveyId`에 parameter로 `authorId`도 일치할 때 불러오도록 조건을 추가하여 `findCertificationTypeBySurveyIdAndAuthorId`로 수정