### PR TITLE
fix: 병합하면서 발생한 충돌 문제 해결

### DIFF
--- a/api/src/main/java/com/thesurvey/api/repository/SurveyRepository.java
+++ b/api/src/main/java/com/thesurvey/api/repository/SurveyRepository.java
@@ -28,7 +28,4 @@ public interface SurveyRepository extends JpaRepository<Survey, UUID> {
     @Query("SELECT new com.thesurvey.api.dto.response.user.UserSurveyTitleDto(s.surveyId, s.title) FROM Survey s WHERE s.authorId = :authorId ORDER BY s.createdDate DESC")
     List<UserSurveyTitleDto> findUserCreatedSurveysByAuthorID(@Param("authorId") Long authorId);
 
-    @Query("SELECT p.certificationType FROM Participation p WHERE p.survey.surveyId = :surveyId AND p.user.userId = :authorId")
-    List<Integer> findCertificationTypeBySurveyIdAndAuthorId(UUID surveyId, Long authorId);
-
 }


### PR DESCRIPTION
이 PR은 #137 를 병합하면서 발생한 충돌을 해결합니다.

**변경 사항**
- `findCertificationTypeBySurveyIdAndAuthorId`가 두 개 존재하던 문제 해결

