### PR TITLE
feat: survey list page, survey participate page 캐시 추가 with react-query

### DIFF
--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.1.0",
       "dependencies": {
         "@tanstack/react-query": "^4.29.7",
+        "@tanstack/react-query-devtools": "^4.29.7",
         "@testing-library/jest-dom": "^5.16.5",
         "@testing-library/react": "^13.4.0",
         "@testing-library/user-event": "^13.5.0",
@@ -3118,6 +3119,21 @@
         "url": "https://github.com/sponsors/gregberge"
       }
     },
+    "node_modules/@tanstack/match-sorter-utils": {
+      "version": "8.8.4",
+      "resolved": "https://registry.npmjs.org/@tanstack/match-sorter-utils/-/match-sorter-utils-8.8.4.tgz",
+      "integrity": "sha512-rKH8LjZiszWEvmi01NR72QWZ8m4xmXre0OOwlRGnjU01Eqz/QnN+cqpty2PJ0efHblq09+KilvyR7lsbzmXVEw==",
+      "dependencies": {
+        "remove-accents": "0.4.2"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/kentcdodds"
+      }
+    },
     "node_modules/@tanstack/query-core": {
       "version": "4.29.7",
       "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-4.29.7.tgz",
@@ -3151,6 +3167,25 @@
         "react-native": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@tanstack/react-query-devtools": {
+      "version": "4.29.7",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-query-devtools/-/react-query-devtools-4.29.7.tgz",
+      "integrity": "sha512-fckNnBV6Kfbtq6EJqQen8oBjPqGFcOPS9SJmNKLbFLQgd7OpNIlA4M0r37iJYUY9m14/ESKc1wzKd36VfeiPjg==",
+      "dependencies": {
+        "@tanstack/match-sorter-utils": "^8.7.0",
+        "superjson": "^1.10.0",
+        "use-sync-external-store": "^1.2.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "@tanstack/react-query": "4.29.7",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0",
+        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0"
       }
     },
     "node_modules/@testing-library/dom": {
@@ -6204,6 +6239,20 @@
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
       "integrity": "sha512-QADzlaHc8icV8I7vbaJXJwod9HWYp8uCqf1xa4OfNu1T7JVxQIrUgOWtHdNDtPiywmFbiS12VjotIXLrKM3orQ=="
+    },
+    "node_modules/copy-anything": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/copy-anything/-/copy-anything-3.0.4.tgz",
+      "integrity": "sha512-MaQ9FwzlZ/KLeVCLhzI3rZw0EhrIryfZa3AyT4agVybR0DjlkDHA8898lamLD6kfkf9MMn8D+zDAUR4+GxaymQ==",
+      "dependencies": {
+        "is-what": "^4.1.8"
+      },
+      "engines": {
+        "node": ">=12.13"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/mesqueeb"
+      }
     },
     "node_modules/core-js": {
       "version": "3.28.0",
@@ -9882,6 +9931,17 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-what": {
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/is-what/-/is-what-4.1.9.tgz",
+      "integrity": "sha512-I3FU0rkVvwhgLLEs6iITwZ/JaLXe7tQcHyzupXky8jigt1vu4KM0UOqDr963j36JRvJ835EATVIm6MnGz/i1/g==",
+      "engines": {
+        "node": ">=12.13"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/mesqueeb"
       }
     },
     "node_modules/is-wsl": {
@@ -15733,6 +15793,11 @@
         "node": ">= 0.10"
       }
     },
+    "node_modules/remove-accents": {
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/remove-accents/-/remove-accents-0.4.2.tgz",
+      "integrity": "sha512-7pXIJqJOq5tFgG1A2Zxti3Ht8jJF337m4sowbuHsW30ZnkQFnDzy9qBNhgzX8ZLW4+UBcXiiR7SwR6pokHsxiA=="
+    },
     "node_modules/renderkid": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/renderkid/-/renderkid-3.0.0.tgz",
@@ -16844,6 +16909,17 @@
       },
       "peerDependencies": {
         "postcss": "^8.2.15"
+      }
+    },
+    "node_modules/superjson": {
+      "version": "1.12.3",
+      "resolved": "https://registry.npmjs.org/superjson/-/superjson-1.12.3.tgz",
+      "integrity": "sha512-0j+U70KUtP8+roVPbwfqkyQI7lBt7ETnuA7KXbTDX3mCKiD/4fXs2ldKSMdt0MCfpTwiMxo20yFU3vu6ewETpQ==",
+      "dependencies": {
+        "copy-anything": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/supports-color": {
@@ -20582,6 +20658,14 @@
         "loader-utils": "^2.0.0"
       }
     },
+    "@tanstack/match-sorter-utils": {
+      "version": "8.8.4",
+      "resolved": "https://registry.npmjs.org/@tanstack/match-sorter-utils/-/match-sorter-utils-8.8.4.tgz",
+      "integrity": "sha512-rKH8LjZiszWEvmi01NR72QWZ8m4xmXre0OOwlRGnjU01Eqz/QnN+cqpty2PJ0efHblq09+KilvyR7lsbzmXVEw==",
+      "requires": {
+        "remove-accents": "0.4.2"
+      }
+    },
     "@tanstack/query-core": {
       "version": "4.29.7",
       "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-4.29.7.tgz",
@@ -20593,6 +20677,16 @@
       "integrity": "sha512-ijBWEzAIo09fB1yd22slRZzprrZ5zMdWYzBnCg5qiXuFbH78uGN1qtGz8+Ed4MuhaPaYSD+hykn+QEKtQviEtg==",
       "requires": {
         "@tanstack/query-core": "4.29.7",
+        "use-sync-external-store": "^1.2.0"
+      }
+    },
+    "@tanstack/react-query-devtools": {
+      "version": "4.29.7",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-query-devtools/-/react-query-devtools-4.29.7.tgz",
+      "integrity": "sha512-fckNnBV6Kfbtq6EJqQen8oBjPqGFcOPS9SJmNKLbFLQgd7OpNIlA4M0r37iJYUY9m14/ESKc1wzKd36VfeiPjg==",
+      "requires": {
+        "@tanstack/match-sorter-utils": "^8.7.0",
+        "superjson": "^1.10.0",
         "use-sync-external-store": "^1.2.0"
       }
     },
@@ -22868,6 +22962,14 @@
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
       "integrity": "sha512-QADzlaHc8icV8I7vbaJXJwod9HWYp8uCqf1xa4OfNu1T7JVxQIrUgOWtHdNDtPiywmFbiS12VjotIXLrKM3orQ=="
+    },
+    "copy-anything": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/copy-anything/-/copy-anything-3.0.4.tgz",
+      "integrity": "sha512-MaQ9FwzlZ/KLeVCLhzI3rZw0EhrIryfZa3AyT4agVybR0DjlkDHA8898lamLD6kfkf9MMn8D+zDAUR4+GxaymQ==",
+      "requires": {
+        "is-what": "^4.1.8"
+      }
     },
     "core-js": {
       "version": "3.28.0",
@@ -25488,6 +25590,11 @@
         "call-bind": "^1.0.2",
         "get-intrinsic": "^1.1.1"
       }
+    },
+    "is-what": {
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/is-what/-/is-what-4.1.9.tgz",
+      "integrity": "sha512-I3FU0rkVvwhgLLEs6iITwZ/JaLXe7tQcHyzupXky8jigt1vu4KM0UOqDr963j36JRvJ835EATVIm6MnGz/i1/g=="
     },
     "is-wsl": {
       "version": "2.2.0",
@@ -29663,6 +29770,11 @@
       "resolved": "https://registry.npmjs.org/relateurl/-/relateurl-0.2.7.tgz",
       "integrity": "sha512-G08Dxvm4iDN3MLM0EsP62EDV9IuhXPR6blNz6Utcp7zyV3tr4HVNINt6MpaRWbxoOHT3Q7YN2P+jaHX8vUbgog=="
     },
+    "remove-accents": {
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/remove-accents/-/remove-accents-0.4.2.tgz",
+      "integrity": "sha512-7pXIJqJOq5tFgG1A2Zxti3Ht8jJF337m4sowbuHsW30ZnkQFnDzy9qBNhgzX8ZLW4+UBcXiiR7SwR6pokHsxiA=="
+    },
     "renderkid": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/renderkid/-/renderkid-3.0.0.tgz",
@@ -30474,6 +30586,14 @@
       "requires": {
         "browserslist": "^4.21.4",
         "postcss-selector-parser": "^6.0.4"
+      }
+    },
+    "superjson": {
+      "version": "1.12.3",
+      "resolved": "https://registry.npmjs.org/superjson/-/superjson-1.12.3.tgz",
+      "integrity": "sha512-0j+U70KUtP8+roVPbwfqkyQI7lBt7ETnuA7KXbTDX3mCKiD/4fXs2ldKSMdt0MCfpTwiMxo20yFU3vu6ewETpQ==",
+      "requires": {
+        "copy-anything": "^3.0.2"
       }
     },
     "supports-color": {

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -8,6 +8,7 @@
       "name": "web",
       "version": "0.1.0",
       "dependencies": {
+        "@tanstack/react-query": "^4.29.7",
         "@testing-library/jest-dom": "^5.16.5",
         "@testing-library/react": "^13.4.0",
         "@testing-library/user-event": "^13.5.0",
@@ -24,7 +25,6 @@
         "pace-js": "^1.2.4",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
-        "react-query": "^3.39.3",
         "react-redux": "^8.0.5",
         "react-router-dom": "^6.8.2",
         "react-scripts": "5.0.1",
@@ -3118,6 +3118,41 @@
         "url": "https://github.com/sponsors/gregberge"
       }
     },
+    "node_modules/@tanstack/query-core": {
+      "version": "4.29.7",
+      "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-4.29.7.tgz",
+      "integrity": "sha512-GXG4b5hV2Loir+h2G+RXhJdoZhJLnrBWsuLB2r0qBRyhWuXq9w/dWxzvpP89H0UARlH6Mr9DiVj4SMtpkF/aUA==",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      }
+    },
+    "node_modules/@tanstack/react-query": {
+      "version": "4.29.7",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-4.29.7.tgz",
+      "integrity": "sha512-ijBWEzAIo09fB1yd22slRZzprrZ5zMdWYzBnCg5qiXuFbH78uGN1qtGz8+Ed4MuhaPaYSD+hykn+QEKtQviEtg==",
+      "dependencies": {
+        "@tanstack/query-core": "4.29.7",
+        "use-sync-external-store": "^1.2.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0",
+        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0",
+        "react-native": "*"
+      },
+      "peerDependenciesMeta": {
+        "react-dom": {
+          "optional": true
+        },
+        "react-native": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@testing-library/dom": {
       "version": "9.0.0",
       "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-9.0.0.tgz",
@@ -5362,14 +5397,6 @@
         "node": ">= 8.0.0"
       }
     },
-    "node_modules/big-integer": {
-      "version": "1.6.51",
-      "resolved": "https://registry.npmjs.org/big-integer/-/big-integer-1.6.51.tgz",
-      "integrity": "sha512-GPEid2Y9QU1Exl1rpO9B2IPJGHPSupF5GnVIP0blYvNOMer2bTvSWs1jGOUg04hTmu67nmLsQ9TBo1puaotBHg==",
-      "engines": {
-        "node": ">=0.6"
-      }
-    },
     "node_modules/big.js": {
       "version": "5.2.2",
       "resolved": "https://registry.npmjs.org/big.js/-/big.js-5.2.2.tgz",
@@ -5611,21 +5638,6 @@
       },
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/broadcast-channel": {
-      "version": "3.7.0",
-      "resolved": "https://registry.npmjs.org/broadcast-channel/-/broadcast-channel-3.7.0.tgz",
-      "integrity": "sha512-cIAKJXAxGJceNZGTZSBzMxzyOn72cVgPnKx4dc6LRjQgbaJUQqhy5rzL3zbMxkMWsGKkv2hSFkPRMEXfoMZ2Mg==",
-      "dependencies": {
-        "@babel/runtime": "^7.7.2",
-        "detect-node": "^2.1.0",
-        "js-sha3": "0.8.0",
-        "microseconds": "0.2.0",
-        "nano-time": "1.0.0",
-        "oblivious-set": "1.0.0",
-        "rimraf": "3.0.2",
-        "unload": "2.2.0"
       }
     },
     "node_modules/browser-process-hrtime": {
@@ -11403,11 +11415,6 @@
         "url": "https://opencollective.com/js-sdsl"
       }
     },
-    "node_modules/js-sha3": {
-      "version": "0.8.0",
-      "resolved": "https://registry.npmjs.org/js-sha3/-/js-sha3-0.8.0.tgz",
-      "integrity": "sha512-gF1cRrHhIzNfToc802P800N8PpXS+evLLXfsVpowqmAFR9uwbi89WvXg2QspOmXL8QL86J4T1EpFu+yUkwJY3Q=="
-    },
     "node_modules/js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -11751,15 +11758,6 @@
         "tmpl": "1.0.5"
       }
     },
-    "node_modules/match-sorter": {
-      "version": "6.3.1",
-      "resolved": "https://registry.npmjs.org/match-sorter/-/match-sorter-6.3.1.tgz",
-      "integrity": "sha512-mxybbo3pPNuA+ZuCUhm5bwNkXrJTbsk5VWbR5wiwz/GC6LIiegBGn2w3O08UG/jdbYLinw51fSQ5xNU1U3MgBw==",
-      "dependencies": {
-        "@babel/runtime": "^7.12.5",
-        "remove-accents": "0.4.2"
-      }
-    },
     "node_modules/mdn-data": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.0.4.tgz",
@@ -11821,11 +11819,6 @@
       "engines": {
         "node": ">=8.6"
       }
-    },
-    "node_modules/microseconds": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/microseconds/-/microseconds-0.2.0.tgz",
-      "integrity": "sha512-n7DHHMjR1avBbSpsTBj6fmMGh2AGrifVV4e+WYc3Q9lO+xnSZ3NyhcBND3vzzatt05LFhoKFRxrIyklmLlUtyA=="
     },
     "node_modules/mime": {
       "version": "1.6.0",
@@ -11990,14 +11983,6 @@
       },
       "bin": {
         "multicast-dns": "cli.js"
-      }
-    },
-    "node_modules/nano-time": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/nano-time/-/nano-time-1.0.0.tgz",
-      "integrity": "sha512-flnngywOoQ0lLQOTRNexn2gGSNuM9bKj9RZAWSzhQ+UJYaAFG9bac4DW9VHjUAzrOaIcajHybCTHe/bkvozQqA==",
-      "dependencies": {
-        "big-integer": "^1.6.16"
       }
     },
     "node_modules/nanoid": {
@@ -12252,11 +12237,6 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
-    },
-    "node_modules/oblivious-set": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/oblivious-set/-/oblivious-set-1.0.0.tgz",
-      "integrity": "sha512-z+pI07qxo4c2CulUHCDf9lcqDlMSo72N/4rLUpRXf6fu+q8vjt8y0xS+Tlf8NTJDdTXHbdeO1n3MlbctwEoXZw=="
     },
     "node_modules/obuf": {
       "version": "1.1.2",
@@ -14288,31 +14268,6 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w=="
     },
-    "node_modules/react-query": {
-      "version": "3.39.3",
-      "resolved": "https://registry.npmjs.org/react-query/-/react-query-3.39.3.tgz",
-      "integrity": "sha512-nLfLz7GiohKTJDuT4us4X3h/8unOh+00MLb2yJoGTPjxKs2bc1iDhkNx2bd5MKklXnOD3NrVZ+J2UXujA5In4g==",
-      "dependencies": {
-        "@babel/runtime": "^7.5.5",
-        "broadcast-channel": "^3.4.1",
-        "match-sorter": "^6.0.2"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/tannerlinsley"
-      },
-      "peerDependencies": {
-        "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
-      },
-      "peerDependenciesMeta": {
-        "react-dom": {
-          "optional": true
-        },
-        "react-native": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/react-redux": {
       "version": "8.0.5",
       "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-8.0.5.tgz",
@@ -15777,11 +15732,6 @@
       "engines": {
         "node": ">= 0.10"
       }
-    },
-    "node_modules/remove-accents": {
-      "version": "0.4.2",
-      "resolved": "https://registry.npmjs.org/remove-accents/-/remove-accents-0.4.2.tgz",
-      "integrity": "sha512-7pXIJqJOq5tFgG1A2Zxti3Ht8jJF337m4sowbuHsW30ZnkQFnDzy9qBNhgzX8ZLW4+UBcXiiR7SwR6pokHsxiA=="
     },
     "node_modules/renderkid": {
       "version": "3.0.0",
@@ -17492,15 +17442,6 @@
       "integrity": "sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ==",
       "engines": {
         "node": ">= 10.0.0"
-      }
-    },
-    "node_modules/unload": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/unload/-/unload-2.2.0.tgz",
-      "integrity": "sha512-B60uB5TNBLtN6/LsgAf3udH9saB5p7gqJwcFfbOEZ8BcBHnGwCf6G/TGiEqkRAxX7zAFIUtzdrXQSdL3Q/wqNA==",
-      "dependencies": {
-        "@babel/runtime": "^7.6.2",
-        "detect-node": "^2.0.4"
       }
     },
     "node_modules/unpipe": {
@@ -20641,6 +20582,20 @@
         "loader-utils": "^2.0.0"
       }
     },
+    "@tanstack/query-core": {
+      "version": "4.29.7",
+      "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-4.29.7.tgz",
+      "integrity": "sha512-GXG4b5hV2Loir+h2G+RXhJdoZhJLnrBWsuLB2r0qBRyhWuXq9w/dWxzvpP89H0UARlH6Mr9DiVj4SMtpkF/aUA=="
+    },
+    "@tanstack/react-query": {
+      "version": "4.29.7",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-4.29.7.tgz",
+      "integrity": "sha512-ijBWEzAIo09fB1yd22slRZzprrZ5zMdWYzBnCg5qiXuFbH78uGN1qtGz8+Ed4MuhaPaYSD+hykn+QEKtQviEtg==",
+      "requires": {
+        "@tanstack/query-core": "4.29.7",
+        "use-sync-external-store": "^1.2.0"
+      }
+    },
     "@testing-library/dom": {
       "version": "9.0.0",
       "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-9.0.0.tgz",
@@ -22334,11 +22289,6 @@
         "tryer": "^1.0.1"
       }
     },
-    "big-integer": {
-      "version": "1.6.51",
-      "resolved": "https://registry.npmjs.org/big-integer/-/big-integer-1.6.51.tgz",
-      "integrity": "sha512-GPEid2Y9QU1Exl1rpO9B2IPJGHPSupF5GnVIP0blYvNOMer2bTvSWs1jGOUg04hTmu67nmLsQ9TBo1puaotBHg=="
-    },
     "big.js": {
       "version": "5.2.2",
       "resolved": "https://registry.npmjs.org/big.js/-/big.js-5.2.2.tgz",
@@ -22511,21 +22461,6 @@
       "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
       "requires": {
         "fill-range": "^7.0.1"
-      }
-    },
-    "broadcast-channel": {
-      "version": "3.7.0",
-      "resolved": "https://registry.npmjs.org/broadcast-channel/-/broadcast-channel-3.7.0.tgz",
-      "integrity": "sha512-cIAKJXAxGJceNZGTZSBzMxzyOn72cVgPnKx4dc6LRjQgbaJUQqhy5rzL3zbMxkMWsGKkv2hSFkPRMEXfoMZ2Mg==",
-      "requires": {
-        "@babel/runtime": "^7.7.2",
-        "detect-node": "^2.1.0",
-        "js-sha3": "0.8.0",
-        "microseconds": "0.2.0",
-        "nano-time": "1.0.0",
-        "oblivious-set": "1.0.0",
-        "rimraf": "3.0.2",
-        "unload": "2.2.0"
       }
     },
     "browser-process-hrtime": {
@@ -26728,11 +26663,6 @@
       "resolved": "https://registry.npmjs.org/js-sdsl/-/js-sdsl-4.3.0.tgz",
       "integrity": "sha512-mifzlm2+5nZ+lEcLJMoBK0/IH/bDg8XnJfd/Wq6IP+xoCjLZsTOnV2QpxlVbX9bMnkl5PdEjNtBJ9Cj1NjifhQ=="
     },
-    "js-sha3": {
-      "version": "0.8.0",
-      "resolved": "https://registry.npmjs.org/js-sha3/-/js-sha3-0.8.0.tgz",
-      "integrity": "sha512-gF1cRrHhIzNfToc802P800N8PpXS+evLLXfsVpowqmAFR9uwbi89WvXg2QspOmXL8QL86J4T1EpFu+yUkwJY3Q=="
-    },
     "js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -26999,15 +26929,6 @@
         "tmpl": "1.0.5"
       }
     },
-    "match-sorter": {
-      "version": "6.3.1",
-      "resolved": "https://registry.npmjs.org/match-sorter/-/match-sorter-6.3.1.tgz",
-      "integrity": "sha512-mxybbo3pPNuA+ZuCUhm5bwNkXrJTbsk5VWbR5wiwz/GC6LIiegBGn2w3O08UG/jdbYLinw51fSQ5xNU1U3MgBw==",
-      "requires": {
-        "@babel/runtime": "^7.12.5",
-        "remove-accents": "0.4.2"
-      }
-    },
     "mdn-data": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.0.4.tgz",
@@ -27054,11 +26975,6 @@
         "braces": "^3.0.2",
         "picomatch": "^2.3.1"
       }
-    },
-    "microseconds": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/microseconds/-/microseconds-0.2.0.tgz",
-      "integrity": "sha512-n7DHHMjR1avBbSpsTBj6fmMGh2AGrifVV4e+WYc3Q9lO+xnSZ3NyhcBND3vzzatt05LFhoKFRxrIyklmLlUtyA=="
     },
     "mime": {
       "version": "1.6.0",
@@ -27171,14 +27087,6 @@
       "requires": {
         "dns-packet": "^5.2.2",
         "thunky": "^1.0.2"
-      }
-    },
-    "nano-time": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/nano-time/-/nano-time-1.0.0.tgz",
-      "integrity": "sha512-flnngywOoQ0lLQOTRNexn2gGSNuM9bKj9RZAWSzhQ+UJYaAFG9bac4DW9VHjUAzrOaIcajHybCTHe/bkvozQqA==",
-      "requires": {
-        "big-integer": "^1.6.16"
       }
     },
     "nanoid": {
@@ -27355,11 +27263,6 @@
         "define-properties": "^1.1.4",
         "es-abstract": "^1.20.4"
       }
-    },
-    "oblivious-set": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/oblivious-set/-/oblivious-set-1.0.0.tgz",
-      "integrity": "sha512-z+pI07qxo4c2CulUHCDf9lcqDlMSo72N/4rLUpRXf6fu+q8vjt8y0xS+Tlf8NTJDdTXHbdeO1n3MlbctwEoXZw=="
     },
     "obuf": {
       "version": "1.1.2",
@@ -28648,16 +28551,6 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w=="
     },
-    "react-query": {
-      "version": "3.39.3",
-      "resolved": "https://registry.npmjs.org/react-query/-/react-query-3.39.3.tgz",
-      "integrity": "sha512-nLfLz7GiohKTJDuT4us4X3h/8unOh+00MLb2yJoGTPjxKs2bc1iDhkNx2bd5MKklXnOD3NrVZ+J2UXujA5In4g==",
-      "requires": {
-        "@babel/runtime": "^7.5.5",
-        "broadcast-channel": "^3.4.1",
-        "match-sorter": "^6.0.2"
-      }
-    },
     "react-redux": {
       "version": "8.0.5",
       "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-8.0.5.tgz",
@@ -29769,11 +29662,6 @@
       "version": "0.2.7",
       "resolved": "https://registry.npmjs.org/relateurl/-/relateurl-0.2.7.tgz",
       "integrity": "sha512-G08Dxvm4iDN3MLM0EsP62EDV9IuhXPR6blNz6Utcp7zyV3tr4HVNINt6MpaRWbxoOHT3Q7YN2P+jaHX8vUbgog=="
-    },
-    "remove-accents": {
-      "version": "0.4.2",
-      "resolved": "https://registry.npmjs.org/remove-accents/-/remove-accents-0.4.2.tgz",
-      "integrity": "sha512-7pXIJqJOq5tFgG1A2Zxti3Ht8jJF337m4sowbuHsW30ZnkQFnDzy9qBNhgzX8ZLW4+UBcXiiR7SwR6pokHsxiA=="
     },
     "renderkid": {
       "version": "3.0.0",
@@ -31032,15 +30920,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.0.tgz",
       "integrity": "sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ=="
-    },
-    "unload": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/unload/-/unload-2.2.0.tgz",
-      "integrity": "sha512-B60uB5TNBLtN6/LsgAf3udH9saB5p7gqJwcFfbOEZ8BcBHnGwCf6G/TGiEqkRAxX7zAFIUtzdrXQSdL3Q/wqNA==",
-      "requires": {
-        "@babel/runtime": "^7.6.2",
-        "detect-node": "^2.0.4"
-      }
     },
     "unpipe": {
       "version": "1.0.0",

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -24,6 +24,7 @@
         "pace-js": "^1.2.4",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
+        "react-query": "^3.39.3",
         "react-redux": "^8.0.5",
         "react-router-dom": "^6.8.2",
         "react-scripts": "5.0.1",
@@ -5361,6 +5362,14 @@
         "node": ">= 8.0.0"
       }
     },
+    "node_modules/big-integer": {
+      "version": "1.6.51",
+      "resolved": "https://registry.npmjs.org/big-integer/-/big-integer-1.6.51.tgz",
+      "integrity": "sha512-GPEid2Y9QU1Exl1rpO9B2IPJGHPSupF5GnVIP0blYvNOMer2bTvSWs1jGOUg04hTmu67nmLsQ9TBo1puaotBHg==",
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
     "node_modules/big.js": {
       "version": "5.2.2",
       "resolved": "https://registry.npmjs.org/big.js/-/big.js-5.2.2.tgz",
@@ -5602,6 +5611,21 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/broadcast-channel": {
+      "version": "3.7.0",
+      "resolved": "https://registry.npmjs.org/broadcast-channel/-/broadcast-channel-3.7.0.tgz",
+      "integrity": "sha512-cIAKJXAxGJceNZGTZSBzMxzyOn72cVgPnKx4dc6LRjQgbaJUQqhy5rzL3zbMxkMWsGKkv2hSFkPRMEXfoMZ2Mg==",
+      "dependencies": {
+        "@babel/runtime": "^7.7.2",
+        "detect-node": "^2.1.0",
+        "js-sha3": "0.8.0",
+        "microseconds": "0.2.0",
+        "nano-time": "1.0.0",
+        "oblivious-set": "1.0.0",
+        "rimraf": "3.0.2",
+        "unload": "2.2.0"
       }
     },
     "node_modules/browser-process-hrtime": {
@@ -11379,6 +11403,11 @@
         "url": "https://opencollective.com/js-sdsl"
       }
     },
+    "node_modules/js-sha3": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/js-sha3/-/js-sha3-0.8.0.tgz",
+      "integrity": "sha512-gF1cRrHhIzNfToc802P800N8PpXS+evLLXfsVpowqmAFR9uwbi89WvXg2QspOmXL8QL86J4T1EpFu+yUkwJY3Q=="
+    },
     "node_modules/js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -11722,6 +11751,15 @@
         "tmpl": "1.0.5"
       }
     },
+    "node_modules/match-sorter": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/match-sorter/-/match-sorter-6.3.1.tgz",
+      "integrity": "sha512-mxybbo3pPNuA+ZuCUhm5bwNkXrJTbsk5VWbR5wiwz/GC6LIiegBGn2w3O08UG/jdbYLinw51fSQ5xNU1U3MgBw==",
+      "dependencies": {
+        "@babel/runtime": "^7.12.5",
+        "remove-accents": "0.4.2"
+      }
+    },
     "node_modules/mdn-data": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.0.4.tgz",
@@ -11783,6 +11821,11 @@
       "engines": {
         "node": ">=8.6"
       }
+    },
+    "node_modules/microseconds": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/microseconds/-/microseconds-0.2.0.tgz",
+      "integrity": "sha512-n7DHHMjR1avBbSpsTBj6fmMGh2AGrifVV4e+WYc3Q9lO+xnSZ3NyhcBND3vzzatt05LFhoKFRxrIyklmLlUtyA=="
     },
     "node_modules/mime": {
       "version": "1.6.0",
@@ -11947,6 +11990,14 @@
       },
       "bin": {
         "multicast-dns": "cli.js"
+      }
+    },
+    "node_modules/nano-time": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/nano-time/-/nano-time-1.0.0.tgz",
+      "integrity": "sha512-flnngywOoQ0lLQOTRNexn2gGSNuM9bKj9RZAWSzhQ+UJYaAFG9bac4DW9VHjUAzrOaIcajHybCTHe/bkvozQqA==",
+      "dependencies": {
+        "big-integer": "^1.6.16"
       }
     },
     "node_modules/nanoid": {
@@ -12201,6 +12252,11 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/oblivious-set": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/oblivious-set/-/oblivious-set-1.0.0.tgz",
+      "integrity": "sha512-z+pI07qxo4c2CulUHCDf9lcqDlMSo72N/4rLUpRXf6fu+q8vjt8y0xS+Tlf8NTJDdTXHbdeO1n3MlbctwEoXZw=="
     },
     "node_modules/obuf": {
       "version": "1.1.2",
@@ -14232,6 +14288,31 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w=="
     },
+    "node_modules/react-query": {
+      "version": "3.39.3",
+      "resolved": "https://registry.npmjs.org/react-query/-/react-query-3.39.3.tgz",
+      "integrity": "sha512-nLfLz7GiohKTJDuT4us4X3h/8unOh+00MLb2yJoGTPjxKs2bc1iDhkNx2bd5MKklXnOD3NrVZ+J2UXujA5In4g==",
+      "dependencies": {
+        "@babel/runtime": "^7.5.5",
+        "broadcast-channel": "^3.4.1",
+        "match-sorter": "^6.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
+      },
+      "peerDependenciesMeta": {
+        "react-dom": {
+          "optional": true
+        },
+        "react-native": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/react-redux": {
       "version": "8.0.5",
       "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-8.0.5.tgz",
@@ -15696,6 +15777,11 @@
       "engines": {
         "node": ">= 0.10"
       }
+    },
+    "node_modules/remove-accents": {
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/remove-accents/-/remove-accents-0.4.2.tgz",
+      "integrity": "sha512-7pXIJqJOq5tFgG1A2Zxti3Ht8jJF337m4sowbuHsW30ZnkQFnDzy9qBNhgzX8ZLW4+UBcXiiR7SwR6pokHsxiA=="
     },
     "node_modules/renderkid": {
       "version": "3.0.0",
@@ -17406,6 +17492,15 @@
       "integrity": "sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ==",
       "engines": {
         "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/unload": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/unload/-/unload-2.2.0.tgz",
+      "integrity": "sha512-B60uB5TNBLtN6/LsgAf3udH9saB5p7gqJwcFfbOEZ8BcBHnGwCf6G/TGiEqkRAxX7zAFIUtzdrXQSdL3Q/wqNA==",
+      "dependencies": {
+        "@babel/runtime": "^7.6.2",
+        "detect-node": "^2.0.4"
       }
     },
     "node_modules/unpipe": {
@@ -22239,6 +22334,11 @@
         "tryer": "^1.0.1"
       }
     },
+    "big-integer": {
+      "version": "1.6.51",
+      "resolved": "https://registry.npmjs.org/big-integer/-/big-integer-1.6.51.tgz",
+      "integrity": "sha512-GPEid2Y9QU1Exl1rpO9B2IPJGHPSupF5GnVIP0blYvNOMer2bTvSWs1jGOUg04hTmu67nmLsQ9TBo1puaotBHg=="
+    },
     "big.js": {
       "version": "5.2.2",
       "resolved": "https://registry.npmjs.org/big.js/-/big.js-5.2.2.tgz",
@@ -22411,6 +22511,21 @@
       "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
       "requires": {
         "fill-range": "^7.0.1"
+      }
+    },
+    "broadcast-channel": {
+      "version": "3.7.0",
+      "resolved": "https://registry.npmjs.org/broadcast-channel/-/broadcast-channel-3.7.0.tgz",
+      "integrity": "sha512-cIAKJXAxGJceNZGTZSBzMxzyOn72cVgPnKx4dc6LRjQgbaJUQqhy5rzL3zbMxkMWsGKkv2hSFkPRMEXfoMZ2Mg==",
+      "requires": {
+        "@babel/runtime": "^7.7.2",
+        "detect-node": "^2.1.0",
+        "js-sha3": "0.8.0",
+        "microseconds": "0.2.0",
+        "nano-time": "1.0.0",
+        "oblivious-set": "1.0.0",
+        "rimraf": "3.0.2",
+        "unload": "2.2.0"
       }
     },
     "browser-process-hrtime": {
@@ -26613,6 +26728,11 @@
       "resolved": "https://registry.npmjs.org/js-sdsl/-/js-sdsl-4.3.0.tgz",
       "integrity": "sha512-mifzlm2+5nZ+lEcLJMoBK0/IH/bDg8XnJfd/Wq6IP+xoCjLZsTOnV2QpxlVbX9bMnkl5PdEjNtBJ9Cj1NjifhQ=="
     },
+    "js-sha3": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/js-sha3/-/js-sha3-0.8.0.tgz",
+      "integrity": "sha512-gF1cRrHhIzNfToc802P800N8PpXS+evLLXfsVpowqmAFR9uwbi89WvXg2QspOmXL8QL86J4T1EpFu+yUkwJY3Q=="
+    },
     "js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -26879,6 +26999,15 @@
         "tmpl": "1.0.5"
       }
     },
+    "match-sorter": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/match-sorter/-/match-sorter-6.3.1.tgz",
+      "integrity": "sha512-mxybbo3pPNuA+ZuCUhm5bwNkXrJTbsk5VWbR5wiwz/GC6LIiegBGn2w3O08UG/jdbYLinw51fSQ5xNU1U3MgBw==",
+      "requires": {
+        "@babel/runtime": "^7.12.5",
+        "remove-accents": "0.4.2"
+      }
+    },
     "mdn-data": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.0.4.tgz",
@@ -26925,6 +27054,11 @@
         "braces": "^3.0.2",
         "picomatch": "^2.3.1"
       }
+    },
+    "microseconds": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/microseconds/-/microseconds-0.2.0.tgz",
+      "integrity": "sha512-n7DHHMjR1avBbSpsTBj6fmMGh2AGrifVV4e+WYc3Q9lO+xnSZ3NyhcBND3vzzatt05LFhoKFRxrIyklmLlUtyA=="
     },
     "mime": {
       "version": "1.6.0",
@@ -27037,6 +27171,14 @@
       "requires": {
         "dns-packet": "^5.2.2",
         "thunky": "^1.0.2"
+      }
+    },
+    "nano-time": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/nano-time/-/nano-time-1.0.0.tgz",
+      "integrity": "sha512-flnngywOoQ0lLQOTRNexn2gGSNuM9bKj9RZAWSzhQ+UJYaAFG9bac4DW9VHjUAzrOaIcajHybCTHe/bkvozQqA==",
+      "requires": {
+        "big-integer": "^1.6.16"
       }
     },
     "nanoid": {
@@ -27213,6 +27355,11 @@
         "define-properties": "^1.1.4",
         "es-abstract": "^1.20.4"
       }
+    },
+    "oblivious-set": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/oblivious-set/-/oblivious-set-1.0.0.tgz",
+      "integrity": "sha512-z+pI07qxo4c2CulUHCDf9lcqDlMSo72N/4rLUpRXf6fu+q8vjt8y0xS+Tlf8NTJDdTXHbdeO1n3MlbctwEoXZw=="
     },
     "obuf": {
       "version": "1.1.2",
@@ -28501,6 +28648,16 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w=="
     },
+    "react-query": {
+      "version": "3.39.3",
+      "resolved": "https://registry.npmjs.org/react-query/-/react-query-3.39.3.tgz",
+      "integrity": "sha512-nLfLz7GiohKTJDuT4us4X3h/8unOh+00MLb2yJoGTPjxKs2bc1iDhkNx2bd5MKklXnOD3NrVZ+J2UXujA5In4g==",
+      "requires": {
+        "@babel/runtime": "^7.5.5",
+        "broadcast-channel": "^3.4.1",
+        "match-sorter": "^6.0.2"
+      }
+    },
     "react-redux": {
       "version": "8.0.5",
       "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-8.0.5.tgz",
@@ -29612,6 +29769,11 @@
       "version": "0.2.7",
       "resolved": "https://registry.npmjs.org/relateurl/-/relateurl-0.2.7.tgz",
       "integrity": "sha512-G08Dxvm4iDN3MLM0EsP62EDV9IuhXPR6blNz6Utcp7zyV3tr4HVNINt6MpaRWbxoOHT3Q7YN2P+jaHX8vUbgog=="
+    },
+    "remove-accents": {
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/remove-accents/-/remove-accents-0.4.2.tgz",
+      "integrity": "sha512-7pXIJqJOq5tFgG1A2Zxti3Ht8jJF337m4sowbuHsW30ZnkQFnDzy9qBNhgzX8ZLW4+UBcXiiR7SwR6pokHsxiA=="
     },
     "renderkid": {
       "version": "3.0.0",
@@ -30870,6 +31032,15 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.0.tgz",
       "integrity": "sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ=="
+    },
+    "unload": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/unload/-/unload-2.2.0.tgz",
+      "integrity": "sha512-B60uB5TNBLtN6/LsgAf3udH9saB5p7gqJwcFfbOEZ8BcBHnGwCf6G/TGiEqkRAxX7zAFIUtzdrXQSdL3Q/wqNA==",
+      "requires": {
+        "@babel/runtime": "^7.6.2",
+        "detect-node": "^2.0.4"
+      }
     },
     "unpipe": {
       "version": "1.0.0",

--- a/web/package.json
+++ b/web/package.json
@@ -3,6 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "dependencies": {
+    "@tanstack/react-query": "^4.29.7",
     "@testing-library/jest-dom": "^5.16.5",
     "@testing-library/react": "^13.4.0",
     "@testing-library/user-event": "^13.5.0",
@@ -19,7 +20,6 @@
     "pace-js": "^1.2.4",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
-    "react-query": "^3.39.3",
     "react-redux": "^8.0.5",
     "react-router-dom": "^6.8.2",
     "react-scripts": "5.0.1",

--- a/web/package.json
+++ b/web/package.json
@@ -19,6 +19,7 @@
     "pace-js": "^1.2.4",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
+    "react-query": "^3.39.3",
     "react-redux": "^8.0.5",
     "react-router-dom": "^6.8.2",
     "react-scripts": "5.0.1",

--- a/web/package.json
+++ b/web/package.json
@@ -4,6 +4,7 @@
   "private": true,
   "dependencies": {
     "@tanstack/react-query": "^4.29.7",
+    "@tanstack/react-query-devtools": "^4.29.7",
     "@testing-library/jest-dom": "^5.16.5",
     "@testing-library/react": "^13.4.0",
     "@testing-library/user-event": "^13.5.0",

--- a/web/src/api/fetchFunctions.ts
+++ b/web/src/api/fetchFunctions.ts
@@ -1,0 +1,29 @@
+import { QueryFunctionContext } from '@tanstack/react-query';
+
+import { SurveyPageResponse, SurveyResponse } from '../types/response/Survey';
+import axios from './axios';
+import { requests } from './request';
+
+/**
+ * Get survey page with axios instance
+ *
+ * @param {{ queryKey }} ['surveyPage', pageNumber]
+ * @returns {Promise<SurveyPageResponse>}
+ */
+export const fetchSurveyList = async ({ queryKey }: QueryFunctionContext): Promise<SurveyPageResponse> => {
+  const { data } = await axios.get<SurveyPageResponse>(`${requests.getSurveyPage}${queryKey[1]}`);
+
+  return data;
+};
+
+/**
+ * Get each survey data with axios instance
+ *
+ * @param {{ queryKey }} ['survey', surveyId]
+ * @returns {Promise<SurveyResponse>}
+ */
+export const fetchSurveyData = async ({ queryKey }: QueryFunctionContext): Promise<SurveyResponse> => {
+  const { data } = await axios.get<SurveyResponse>(requests.getSurvey + queryKey[1]);
+
+  return data;
+};

--- a/web/src/components/ErrorPage.tsx
+++ b/web/src/components/ErrorPage.tsx
@@ -1,0 +1,63 @@
+import React from 'react';
+
+import { useNavigate } from 'react-router';
+import styled, { DefaultTheme } from 'styled-components';
+
+import RectangleButton from './Button/RectangleButton';
+import Header from './Header';
+
+const Container = styled.div`
+  width: 100vw;
+  height: 100vh;
+  background-color: ${(props) => props.theme.colors.container};
+`;
+
+const Notification = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  text-align: center;
+  margin-top: 35vh;
+  padding: 10px;
+`;
+
+const Label = styled.label`
+  font-size: 50px;
+  font-weight: 700;
+  color: ${(props) => props.theme.colors.default};
+  text-align: center;
+
+  @media screen and (max-width: 700px) {
+    font-size: 30px;
+  }
+`;
+
+interface ErrorPageProps {
+  labelText: string;
+  buttonText: string;
+  navigateRoute: string;
+  theme: DefaultTheme;
+  toggleTheme: () => void;
+}
+
+export default function ErrorPage({ labelText, buttonText, navigateRoute, theme, toggleTheme }: ErrorPageProps) {
+  const navigate = useNavigate();
+
+  return (
+    <Container theme={theme}>
+      <Header theme={theme} toggleTheme={toggleTheme} />
+      <Notification theme={theme}>
+        <Label theme={theme}>{labelText}</Label>
+        <br />
+        <RectangleButton
+          text={buttonText}
+          width="250px"
+          backgroundColor={theme.colors.primary}
+          hoverColor={theme.colors.prhover}
+          handleClick={() => navigate(`${navigateRoute}`)}
+          theme={theme}
+        />
+      </Notification>
+    </Container>
+  );
+}

--- a/web/src/components/SurveyListTable.tsx
+++ b/web/src/components/SurveyListTable.tsx
@@ -109,6 +109,7 @@ const Label = styled.label`
 
 interface SurveyListTableProps {
   surveys: SurveyAbstractResponse[];
+  errorResponse: string;
   setSelectedSurveyIndex: (arg: number) => void;
   setPreviewModalOpen: (arg: boolean) => void;
   theme: DefaultTheme;
@@ -116,6 +117,7 @@ interface SurveyListTableProps {
 
 export default function SurveyListTable({
   surveys,
+  errorResponse,
   setSelectedSurveyIndex,
   setPreviewModalOpen,
   theme,
@@ -127,7 +129,7 @@ export default function SurveyListTable({
     setPreviewModalOpen(true);
   };
 
-  if (surveys.length === 0) {
+  if (errorResponse === '존재하지 않는 페이지입니다.') {
     return (
       <Notification theme={theme}>
         <Label theme={theme}>😥 참여가능한 설문이 없습니다...</Label>

--- a/web/src/components/SurveyListTable.tsx
+++ b/web/src/components/SurveyListTable.tsx
@@ -1,11 +1,9 @@
 import React from 'react';
 
-import { useNavigate } from 'react-router-dom';
 import styled, { DefaultTheme } from 'styled-components';
 
 import { SurveyAbstractResponse } from '../types/response/Survey';
 import { dateFormatUpToMinute } from '../utils/dateFormat';
-import RectangleButton from './Button/RectangleButton';
 import CertificationIconList from './CertificationIconList';
 
 const ListTable = styled.table`
@@ -87,29 +85,8 @@ const HeadEndDate = styled(HeadItem)`
   }
 `;
 
-const Notification = styled.div`
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  text-align: center;
-  margin-top: 35vh;
-  padding: 10px;
-`;
-
-const Label = styled.label`
-  font-size: 50px;
-  font-weight: 700;
-  color: ${(props) => props.theme.colors.default};
-  text-align: center;
-
-  @media screen and (max-width: 700px) {
-    font-size: 30px;
-  }
-`;
-
 interface SurveyListTableProps {
   surveys: SurveyAbstractResponse[];
-  errorResponse: string;
   setSelectedSurveyIndex: (arg: number) => void;
   setPreviewModalOpen: (arg: boolean) => void;
   theme: DefaultTheme;
@@ -117,34 +94,14 @@ interface SurveyListTableProps {
 
 export default function SurveyListTable({
   surveys,
-  errorResponse,
   setSelectedSurveyIndex,
   setPreviewModalOpen,
   theme,
 }: SurveyListTableProps) {
-  const navigate = useNavigate();
-
   const handleButtonClick = (index: number) => {
     setSelectedSurveyIndex(index);
     setPreviewModalOpen(true);
   };
-
-  if (errorResponse === '존재하지 않는 페이지입니다.') {
-    return (
-      <Notification theme={theme}>
-        <Label theme={theme}>😥 참여가능한 설문이 없습니다...</Label>
-        <br />
-        <RectangleButton
-          text="설문 만들러 가기"
-          width="250px"
-          backgroundColor={theme.colors.primary}
-          hoverColor={theme.colors.prhover}
-          handleClick={() => navigate('/survey/form')}
-          theme={theme}
-        />
-      </Notification>
-    );
-  }
 
   return (
     <ListTable theme={theme}>

--- a/web/src/index.tsx
+++ b/web/src/index.tsx
@@ -1,5 +1,7 @@
 import React from 'react';
 
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { ReactQueryDevtools } from '@tanstack/react-query-devtools';
 import 'pace-js/themes/red/pace-theme-minimal.css';
 import ReactDOM from 'react-dom/client';
 import { Provider } from 'react-redux';
@@ -11,11 +13,15 @@ import { store, persistor } from './reducers/store';
 import reportWebVitals from './reportWebVitals';
 
 const root = ReactDOM.createRoot(document.getElementById('root') as HTMLElement);
+const queryClient = new QueryClient();
 root.render(
   <BrowserRouter>
     <Provider store={store}>
       <PersistGate persistor={persistor}>
-        <App />
+        <QueryClientProvider client={queryClient}>
+          <App />
+          <ReactQueryDevtools />
+        </QueryClientProvider>
       </PersistGate>
     </Provider>
   </BrowserRouter>

--- a/web/src/routes/SurveyPages/SurveyListPage.tsx
+++ b/web/src/routes/SurveyPages/SurveyListPage.tsx
@@ -30,8 +30,8 @@ export default function SurveyListPage() {
 
   // FIXME: cacheTime and staleTime is appropriate?
   const { data, isLoading, isError, error } = useQuery<SurveyPageResponse>(['surveyPage', page], fetchSurveyList, {
-    cacheTime: 9000,
-    staleTime: 60000,
+    cacheTime: 5 * 60 * 1000, // 5 minutes
+    staleTime: 20 * 1000, // 20 seconds
     retry: 1,
     refetchOnWindowFocus: false,
   });

--- a/web/src/routes/SurveyPages/SurveyListPage.tsx
+++ b/web/src/routes/SurveyPages/SurveyListPage.tsx
@@ -2,12 +2,11 @@ import React, { useState } from 'react';
 
 import { QueryFunctionContext, useQuery } from '@tanstack/react-query';
 import { AxiosError } from 'axios';
-import { useNavigate } from 'react-router-dom';
 import styled from 'styled-components';
 
 import axios from '../../api/axios';
 import { requests } from '../../api/request';
-import RectangleButton from '../../components/Button/RectangleButton';
+import ErrorPage from '../../components/ErrorPage';
 import Header from '../../components/Header';
 import { SurveyPreviewModal } from '../../components/Modal';
 import Pagination from '../../components/Pagination';
@@ -24,26 +23,6 @@ const Container = styled.div`
 
 const ListContainer = styled.div``;
 
-const Notification = styled.div`
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  text-align: center;
-  margin-top: 35vh;
-  padding: 10px;
-`;
-
-const Label = styled.label`
-  font-size: 50px;
-  font-weight: 700;
-  color: ${(props) => props.theme.colors.default};
-  text-align: center;
-
-  @media screen and (max-width: 700px) {
-    font-size: 30px;
-  }
-`;
-
 const fetchSurveyList = async ({ queryKey }: QueryFunctionContext) => {
   const { data } = await axios.get<SurveyPageResponse>(`${requests.getSurveyPage}${queryKey[1]}`);
 
@@ -51,7 +30,6 @@ const fetchSurveyList = async ({ queryKey }: QueryFunctionContext) => {
 };
 
 export default function SurveyListPage() {
-  const navigate = useNavigate();
   const [theme, toggleTheme] = useTheme();
   const [page, setPage] = useState<number>(1);
   const [previewModalOpen, setPreviewModalOpen] = useState<boolean>(false);
@@ -71,39 +49,23 @@ export default function SurveyListPage() {
 
     if (response!.data === '존재하지 않는 페이지입니다.') {
       return (
-        <Container theme={theme}>
-          <Header theme={theme} toggleTheme={toggleTheme} />
-          <Notification theme={theme}>
-            <Label theme={theme}>😥 참여가능한 설문이 없습니다...</Label>
-            <br />
-            <RectangleButton
-              text="설문 만들러 가기"
-              width="250px"
-              backgroundColor={theme.colors.primary}
-              hoverColor={theme.colors.prhover}
-              handleClick={() => navigate('/survey/form')}
-              theme={theme}
-            />
-          </Notification>
-        </Container>
+        <ErrorPage
+          labelText="😥 참여가능한 설문이 없습니다..."
+          buttonText="설문 만들러 가기"
+          navigateRoute="/survey/form"
+          theme={theme}
+          toggleTheme={toggleTheme}
+        />
       );
     }
     return (
-      <Container theme={theme}>
-        <Header theme={theme} toggleTheme={toggleTheme} />
-        <Notification theme={theme}>
-          <Label theme={theme}>😥 로그인이 만료 되었습니다...</Label>
-          <br />
-          <RectangleButton
-            text="로그인 하러 가기"
-            width="250px"
-            backgroundColor={theme.colors.primary}
-            hoverColor={theme.colors.prhover}
-            handleClick={() => navigate('/login')}
-            theme={theme}
-          />
-        </Notification>
-      </Container>
+      <ErrorPage
+        labelText="😥 로그인이 만료 되었습니다..."
+        buttonText="로그인 하러 가기"
+        navigateRoute="/login"
+        theme={theme}
+        toggleTheme={toggleTheme}
+      />
     );
   }
 

--- a/web/src/routes/SurveyPages/SurveyListPage.tsx
+++ b/web/src/routes/SurveyPages/SurveyListPage.tsx
@@ -1,11 +1,10 @@
 import React, { useState } from 'react';
 
-import { QueryFunctionContext, useQuery } from '@tanstack/react-query';
+import { useQuery } from '@tanstack/react-query';
 import { AxiosError } from 'axios';
 import styled from 'styled-components';
 
-import axios from '../../api/axios';
-import { requests } from '../../api/request';
+import { fetchSurveyList } from '../../api/fetchFunctions';
 import ErrorPage from '../../components/ErrorPage';
 import Header from '../../components/Header';
 import { SurveyPreviewModal } from '../../components/Modal';
@@ -22,12 +21,6 @@ const Container = styled.div`
 `;
 
 const ListContainer = styled.div``;
-
-const fetchSurveyList = async ({ queryKey }: QueryFunctionContext) => {
-  const { data } = await axios.get<SurveyPageResponse>(`${requests.getSurveyPage}${queryKey[1]}`);
-
-  return data;
-};
 
 export default function SurveyListPage() {
   const [theme, toggleTheme] = useTheme();

--- a/web/src/routes/SurveyPages/SurveyListPage.tsx
+++ b/web/src/routes/SurveyPages/SurveyListPage.tsx
@@ -1,17 +1,20 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState } from 'react';
 
-import { AxiosError, AxiosResponse } from 'axios';
+import { QueryFunctionContext, useQuery } from '@tanstack/react-query';
+import { AxiosError } from 'axios';
+import { useNavigate } from 'react-router-dom';
 import styled from 'styled-components';
 
 import axios from '../../api/axios';
 import { requests } from '../../api/request';
+import RectangleButton from '../../components/Button/RectangleButton';
 import Header from '../../components/Header';
 import { SurveyPreviewModal } from '../../components/Modal';
 import Pagination from '../../components/Pagination';
 import SurveyListSkeleton from '../../components/Skeleton/SurveyListSkeleton';
 import SurveyListTable from '../../components/SurveyListTable';
 import { useTheme } from '../../hooks/useTheme';
-import { SurveyAbstractResponse, SurveyPageResponse } from '../../types/response/Survey';
+import { SurveyPageResponse } from '../../types/response/Survey';
 
 const Container = styled.div`
   width: 100vw;
@@ -21,81 +24,117 @@ const Container = styled.div`
 
 const ListContainer = styled.div``;
 
+const Notification = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  text-align: center;
+  margin-top: 35vh;
+  padding: 10px;
+`;
+
+const Label = styled.label`
+  font-size: 50px;
+  font-weight: 700;
+  color: ${(props) => props.theme.colors.default};
+  text-align: center;
+
+  @media screen and (max-width: 700px) {
+    font-size: 30px;
+  }
+`;
+
+const fetchSurveyList = async ({ queryKey }: QueryFunctionContext) => {
+  const { data } = await axios.get<SurveyPageResponse>(`${requests.getSurveyPage}${queryKey[1]}`);
+
+  return data;
+};
+
 export default function SurveyListPage() {
+  const navigate = useNavigate();
   const [theme, toggleTheme] = useTheme();
-  const [isLoading, setIsLoading] = useState<boolean>(false);
-  const [abortController, setAbortController] = useState<AbortController>(new AbortController());
-  const [surveys, setSurveys] = useState<SurveyAbstractResponse[]>([]);
   const [page, setPage] = useState<number>(1);
-  const [totalPages, setTotalPages] = useState<number>(0);
   const [previewModalOpen, setPreviewModalOpen] = useState<boolean>(false);
   const [selectedSurveyIndex, setSelectedSurveyIndex] = useState<number>(0);
-  const [errorResponse, setErrorResponse] = useState<string>('');
 
-  const fetchSurveyList = async (abortSignal: AbortSignal): Promise<void> => {
-    setIsLoading(true);
-    try {
-      const request: AxiosResponse<SurveyPageResponse> = await axios.get<SurveyPageResponse>(
-        `${requests.getSurveyPage}${page}`,
-        { signal: abortSignal }
+  // FIXME: cacheTime and staleTime is appropriate?
+  const { data, isLoading, isError, error } = useQuery<SurveyPageResponse>(['surveyPage', page], fetchSurveyList, {
+    cacheTime: 9000,
+    staleTime: 60000,
+    retry: 1,
+    refetchOnWindowFocus: false,
+  });
+
+  if (isError) {
+    // TODO: 에러 종류에 따라서 다른 알림 표시
+    const { response } = error as AxiosError;
+
+    if (response!.data === '존재하지 않는 페이지입니다.') {
+      return (
+        <Container theme={theme}>
+          <Header theme={theme} toggleTheme={toggleTheme} />
+          <Notification theme={theme}>
+            <Label theme={theme}>😥 참여가능한 설문이 없습니다...</Label>
+            <br />
+            <RectangleButton
+              text="설문 만들러 가기"
+              width="250px"
+              backgroundColor={theme.colors.primary}
+              hoverColor={theme.colors.prhover}
+              handleClick={() => navigate('/survey/form')}
+              theme={theme}
+            />
+          </Notification>
+        </Container>
       );
-
-      setSurveys(request.data.surveys);
-      setTotalPages(request.data.totalPages);
-      setIsLoading(false);
-    } catch (error) {
-      const { name, response } = error as unknown as AxiosError;
-
-      setErrorResponse((response?.data as string) || '');
-
-      if (name !== 'CanceledError') {
-        setSurveys([]);
-        setIsLoading(false);
-      }
     }
-  };
-
-  useEffect(() => {
-    if (isLoading) {
-      abortController.abort();
-    }
-    const controller = new AbortController();
-    const { signal } = controller;
-    setAbortController(controller);
-    fetchSurveyList(signal);
-  }, [page]);
+    return (
+      <Container theme={theme}>
+        <Header theme={theme} toggleTheme={toggleTheme} />
+        <Notification theme={theme}>
+          <Label theme={theme}>😥 로그인이 만료 되었습니다...</Label>
+          <br />
+          <RectangleButton
+            text="로그인 하러 가기"
+            width="250px"
+            backgroundColor={theme.colors.primary}
+            hoverColor={theme.colors.prhover}
+            handleClick={() => navigate('/login')}
+            theme={theme}
+          />
+        </Notification>
+      </Container>
+    );
+  }
 
   return (
     <Container theme={theme}>
       <Header theme={theme} toggleTheme={toggleTheme} />
-
       {isLoading ? (
         <SurveyListSkeleton numOfSurveyRow={8} theme={theme} />
       ) : (
         <ListContainer>
           <SurveyListTable
             theme={theme}
-            surveys={surveys}
+            surveys={data.surveys}
             setSelectedSurveyIndex={setSelectedSurveyIndex}
             setPreviewModalOpen={setPreviewModalOpen}
-            errorResponse={errorResponse}
           />
+          {previewModalOpen && (
+            <SurveyPreviewModal
+              surveyItem={data.surveys[selectedSurveyIndex]}
+              setPreviewModalOpen={setPreviewModalOpen}
+              theme={theme}
+            />
+          )}
           <Pagination
             currentPage={page}
-            numOfTotalPage={totalPages}
+            numOfTotalPage={data.totalPages}
             numOfPageToShow={5}
             setPage={setPage}
             theme={theme}
           />
         </ListContainer>
-      )}
-
-      {previewModalOpen && (
-        <SurveyPreviewModal
-          surveyItem={surveys[selectedSurveyIndex]}
-          setPreviewModalOpen={setPreviewModalOpen}
-          theme={theme}
-        />
       )}
     </Container>
   );

--- a/web/src/routes/SurveyPages/SurveyListPage.tsx
+++ b/web/src/routes/SurveyPages/SurveyListPage.tsx
@@ -40,7 +40,7 @@ export default function SurveyListPage() {
     // TODO: 에러 종류에 따라서 다른 알림 표시
     const { response } = error as AxiosError;
 
-    if (response!.data === '존재하지 않는 페이지입니다.') {
+    if (response?.data === '존재하지 않는 페이지입니다.') {
       return (
         <ErrorPage
           labelText="😥 참여가능한 설문이 없습니다..."

--- a/web/src/routes/SurveyPages/SurveyListPage.tsx
+++ b/web/src/routes/SurveyPages/SurveyListPage.tsx
@@ -28,7 +28,6 @@ export default function SurveyListPage() {
   const [previewModalOpen, setPreviewModalOpen] = useState<boolean>(false);
   const [selectedSurveyIndex, setSelectedSurveyIndex] = useState<number>(0);
 
-  // FIXME: cacheTime and staleTime is appropriate?
   const { data, isLoading, isError, error } = useQuery<SurveyPageResponse>(['surveyPage', page], fetchSurveyList, {
     cacheTime: 5 * 60 * 1000, // 5 minutes
     staleTime: 20 * 1000, // 20 seconds

--- a/web/src/routes/SurveyPages/SurveyListPage.tsx
+++ b/web/src/routes/SurveyPages/SurveyListPage.tsx
@@ -38,24 +38,28 @@ export default function SurveyListPage() {
 
   if (isError) {
     // TODO: 에러 종류에 따라서 다른 알림 표시
+    // TODO: 에러 처리 로직 분리
     const { response } = error as AxiosError;
 
+    let labelText = '';
+    let buttonText = '';
+    let navigateRoute = '';
+
     if (response?.data === '존재하지 않는 페이지입니다.') {
-      return (
-        <ErrorPage
-          labelText="😥 참여가능한 설문이 없습니다..."
-          buttonText="설문 만들러 가기"
-          navigateRoute="/survey/form"
-          theme={theme}
-          toggleTheme={toggleTheme}
-        />
-      );
+      labelText = '😥 참여가능한 설문이 없습니다...';
+      buttonText = '설문 만들러 가기';
+      navigateRoute = '/survey/form';
+    } else {
+      labelText = '😥 로그인이 만료 되었습니다...';
+      buttonText = '로그인 하러 가기';
+      navigateRoute = '/login';
     }
+
     return (
       <ErrorPage
-        labelText="😥 로그인이 만료 되었습니다..."
-        buttonText="로그인 하러 가기"
-        navigateRoute="/login"
+        labelText={labelText}
+        buttonText={buttonText}
+        navigateRoute={navigateRoute}
         theme={theme}
         toggleTheme={toggleTheme}
       />

--- a/web/src/routes/SurveyPages/SurveyListPage.tsx
+++ b/web/src/routes/SurveyPages/SurveyListPage.tsx
@@ -19,6 +19,8 @@ const Container = styled.div`
   background-color: ${(props) => props.theme.colors.container};
 `;
 
+const ListContainer = styled.div``;
+
 export default function SurveyListPage() {
   const [theme, toggleTheme] = useTheme();
   const [isLoading, setIsLoading] = useState<boolean>(false);
@@ -28,6 +30,7 @@ export default function SurveyListPage() {
   const [totalPages, setTotalPages] = useState<number>(0);
   const [previewModalOpen, setPreviewModalOpen] = useState<boolean>(false);
   const [selectedSurveyIndex, setSelectedSurveyIndex] = useState<number>(0);
+  const [errorResponse, setErrorResponse] = useState<string>('');
 
   const fetchSurveyList = async (abortSignal: AbortSignal): Promise<void> => {
     setIsLoading(true);
@@ -41,7 +44,10 @@ export default function SurveyListPage() {
       setTotalPages(request.data.totalPages);
       setIsLoading(false);
     } catch (error) {
-      const { name } = error as unknown as AxiosError;
+      const { name, response } = error as unknown as AxiosError;
+
+      setErrorResponse((response?.data as string) || '');
+
       if (name !== 'CanceledError') {
         setSurveys([]);
         setIsLoading(false);
@@ -64,24 +70,24 @@ export default function SurveyListPage() {
       <Header theme={theme} toggleTheme={toggleTheme} />
 
       {isLoading ? (
-        <SurveyListSkeleton numOfSurveyRow={10} theme={theme} />
+        <SurveyListSkeleton numOfSurveyRow={8} theme={theme} />
       ) : (
-        <SurveyListTable
-          theme={theme}
-          surveys={surveys}
-          setSelectedSurveyIndex={setSelectedSurveyIndex}
-          setPreviewModalOpen={setPreviewModalOpen}
-        />
-      )}
-
-      {!isLoading && surveys.length !== 0 && (
-        <Pagination
-          currentPage={page}
-          numOfTotalPage={totalPages}
-          numOfPageToShow={5}
-          setPage={setPage}
-          theme={theme}
-        />
+        <ListContainer>
+          <SurveyListTable
+            theme={theme}
+            surveys={surveys}
+            setSelectedSurveyIndex={setSelectedSurveyIndex}
+            setPreviewModalOpen={setPreviewModalOpen}
+            errorResponse={errorResponse}
+          />
+          <Pagination
+            currentPage={page}
+            numOfTotalPage={totalPages}
+            numOfPageToShow={5}
+            setPage={setPage}
+            theme={theme}
+          />
+        </ListContainer>
       )}
 
       {previewModalOpen && (

--- a/web/src/routes/SurveyPages/SurveyPage.tsx
+++ b/web/src/routes/SurveyPages/SurveyPage.tsx
@@ -1,12 +1,11 @@
 import React from 'react';
 
-import { QueryFunctionContext, useQuery } from '@tanstack/react-query';
+import { useQuery } from '@tanstack/react-query';
 import { AxiosError } from 'axios';
 import { useParams } from 'react-router-dom';
 import styled from 'styled-components';
 
-import axios from '../../api/axios';
-import { requests } from '../../api/request';
+import { fetchSurveyData } from '../../api/fetchFunctions';
 import ErrorPage from '../../components/ErrorPage';
 import Header from '../../components/Header';
 import SurveyPageSkeleton from '../../components/Skeleton/SurveyPageSkeleton';
@@ -19,12 +18,6 @@ const Container = styled.div`
   height: 100vh;
   background-color: ${(props) => props.theme.colors.container};
 `;
-
-const fetchSurveyData = async ({ queryKey }: QueryFunctionContext) => {
-  const { data } = await axios.get<SurveyResponse>(requests.getSurvey + queryKey[1]);
-
-  return data;
-};
 
 // TODO: disable submit button after click
 export default function SurveyPage() {

--- a/web/src/routes/SurveyPages/SurveyPage.tsx
+++ b/web/src/routes/SurveyPages/SurveyPage.tsx
@@ -26,8 +26,8 @@ export default function SurveyPage() {
 
   // FIXME: cacheTime and staleTime is appropriate?
   const { data, isLoading, isError, error } = useQuery<SurveyResponse>(['survey', id], fetchSurveyData, {
-    cacheTime: 3000,
-    staleTime: 60000,
+    cacheTime: 15 * 60 * 1000, // 15 minutes
+    staleTime: 10 * 60 * 1000, // 10 minutes
     retry: 1,
     refetchOnWindowFocus: false,
   });

--- a/web/src/routes/SurveyPages/SurveyPage.tsx
+++ b/web/src/routes/SurveyPages/SurveyPage.tsx
@@ -24,7 +24,6 @@ export default function SurveyPage() {
   const { id } = useParams();
   const [theme, toggleTheme] = useTheme();
 
-  // FIXME: cacheTime and staleTime is appropriate?
   const { data, isLoading, isError, error } = useQuery<SurveyResponse>(['survey', id], fetchSurveyData, {
     cacheTime: 15 * 60 * 1000, // 15 minutes
     staleTime: 10 * 60 * 1000, // 10 minutes

--- a/web/src/routes/SurveyPages/SurveyPage.tsx
+++ b/web/src/routes/SurveyPages/SurveyPage.tsx
@@ -34,13 +34,22 @@ export default function SurveyPage() {
 
   if (isError) {
     // TODO: 에러 종류에 따라서 다른 알림 표시
+    // TODO: 에러 처리 로직 분리
     const { response } = error as AxiosError;
+
+    let labelText = '';
+    let buttonText = '';
+    let navigateRoute = '';
+
+    labelText = '😥 잘못된 설문 입니다...';
+    buttonText = '설문 리스트로 돌아가기';
+    navigateRoute = '/survey';
 
     return (
       <ErrorPage
-        labelText="😥 잘못된 설문 입니다..."
-        buttonText="설문 리스트로 돌아가기"
-        navigateRoute="/survey"
+        labelText={labelText}
+        buttonText={buttonText}
+        navigateRoute={navigateRoute}
         theme={theme}
         toggleTheme={toggleTheme}
       />

--- a/web/src/routes/SurveyPages/SurveyPage.tsx
+++ b/web/src/routes/SurveyPages/SurveyPage.tsx
@@ -2,12 +2,12 @@ import React from 'react';
 
 import { QueryFunctionContext, useQuery } from '@tanstack/react-query';
 import { AxiosError } from 'axios';
-import { useNavigate, useParams } from 'react-router-dom';
+import { useParams } from 'react-router-dom';
 import styled from 'styled-components';
 
 import axios from '../../api/axios';
 import { requests } from '../../api/request';
-import RectangleButton from '../../components/Button/RectangleButton';
+import ErrorPage from '../../components/ErrorPage';
 import Header from '../../components/Header';
 import SurveyPageSkeleton from '../../components/Skeleton/SurveyPageSkeleton';
 import SurveyParticipateForm from '../../components/SurveyParticipateForm/SurveyParticipateForm';
@@ -20,26 +20,6 @@ const Container = styled.div`
   background-color: ${(props) => props.theme.colors.container};
 `;
 
-const Notification = styled.div`
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  text-align: center;
-  margin-top: 35vh;
-  padding: 10px;
-`;
-
-const Label = styled.label`
-  font-size: 50px;
-  font-weight: 700;
-  color: ${(props) => props.theme.colors.default};
-  text-align: center;
-
-  @media screen and (max-width: 700px) {
-    font-size: 30px;
-  }
-`;
-
 const fetchSurveyData = async ({ queryKey }: QueryFunctionContext) => {
   const { data } = await axios.get<SurveyResponse>(requests.getSurvey + queryKey[1]);
 
@@ -50,7 +30,6 @@ const fetchSurveyData = async ({ queryKey }: QueryFunctionContext) => {
 export default function SurveyPage() {
   const { id } = useParams();
   const [theme, toggleTheme] = useTheme();
-  const navigate = useNavigate();
 
   // FIXME: cacheTime and staleTime is appropriate?
   const { data, isLoading, isError, error } = useQuery<SurveyResponse>(['survey', id], fetchSurveyData, {
@@ -65,21 +44,13 @@ export default function SurveyPage() {
     const { response } = error as AxiosError;
 
     return (
-      <Container theme={theme}>
-        <Header theme={theme} toggleTheme={toggleTheme} />
-        <Notification theme={theme}>
-          <Label theme={theme}>😥 잘못된 설문 입니다...</Label>
-          <br />
-          <RectangleButton
-            text="설문 리스트로 돌아가기"
-            width="250px"
-            backgroundColor={theme.colors.primary}
-            hoverColor={theme.colors.prhover}
-            handleClick={() => navigate('/survey')}
-            theme={theme}
-          />
-        </Notification>
-      </Container>
+      <ErrorPage
+        labelText="😥 잘못된 설문 입니다..."
+        buttonText="설문 리스트로 돌아가기"
+        navigateRoute="/survey"
+        theme={theme}
+        toggleTheme={toggleTheme}
+      />
     );
   }
 


### PR DESCRIPTION
1. React-query and devtools
> - [React-query 설명(한글)](https://github.com/ssi02014/react-query-tutorial)
> - 설치 : `npm ci `


2. Issue #148 
> -  `surveys` 초기값이 `[]` 인데 `surveys.length === 0` 일 때 `"참여가능한 설문이 없습니다..."` 보여주게 로직이 잘못 구현 되어 있었습니다.
> - `404 리턴(존재하지 않는 페이지입니다.)` 받았을 때만 `"참여가능한 설문이 없습니다..."` 보여주게 변경했습니다.
> -  물론 이렇게 해도 리프레시 연속으로 했을 때 비어있는 `surveys` 출력 해주는것은 동일합니다.
> -  react-query 이용해서 `isLoading` 이 끝났을 때만 `surveys`가 출력될 수 있도록 변경했습니다.

3. survey list page 오류 처리
> - 404: `"참여가능한 설문이 없습니다..."`
> - 401: `"로그인이 만료 되었습니다..."`
>- 추후 추가 예정

4. survey participate page 오류 처리
> - `"잘못된 설문 입니다..."`
> - 추후 추가 예정

Closes #148 