### PR TITLE
fix: 설문조사가 없을 때 페이지 요청 시 `NotFoundException` 을 발생시키는 이슈 해결

### DIFF
--- a/api/src/main/java/com/thesurvey/api/service/SurveyService.java
+++ b/api/src/main/java/com/thesurvey/api/service/SurveyService.java
@@ -81,7 +81,7 @@ public class SurveyService {
 
         Page<Survey> surveyPage = surveyRepository.findAllInDescendingOrder(
             PageRequest.of(page - 1, 8));
-        if (surveyPage.getTotalPages() < page) {
+        if (surveyPage.getTotalElements() != 0 && surveyPage.getTotalPages() < page) {
             throw new NotFoundExceptionMapper(ErrorMessage.PAGE_NOT_FOUND);
         }
 


### PR DESCRIPTION
#164 이슈를 해결합니다.

**변경 사항**
- 설문조사 페이지 요청 시 총 설문조사 수를 검사하는 `NotFoundException` 발생 조건을 추가하였습니다.