### PR TITLE
fix: 설문조사 정보 조회 요청시 `isRequired` 정보 추가

### DIFF
--- a/api/src/main/java/com/thesurvey/api/dto/response/question/QuestionBankResponseDto.java
+++ b/api/src/main/java/com/thesurvey/api/dto/response/question/QuestionBankResponseDto.java
@@ -22,6 +22,9 @@ public class QuestionBankResponseDto {
     @Schema(example = "카카오톡 사용자여부 확인", description = "질문은행 아이디에 해당하는 질문 내용입니다.")
     private String description;
 
+    @Schema(example = "true", description = "필수 응답 질문인지 여부입니다.")
+    private Boolean isRequired;
+
     @Schema(example = "SINGLE_CHOICE", description = "질문은행 아이디에 해당하는 질문 유형입니다.")
     private QuestionType questionType;
 

--- a/api/src/main/java/com/thesurvey/api/repository/QuestionRepository.java
+++ b/api/src/main/java/com/thesurvey/api/repository/QuestionRepository.java
@@ -25,4 +25,7 @@ public interface QuestionRepository extends JpaRepository<Question, QuestionId> 
 
     @Query("SELECT q FROM Question q WHERE q.questionBank.questionBankId = :questionBankId")
     Optional<Question> findByQuestionBankId(Long questionBankId);
+
+    @Query("SELECT q.isRequired FROM Question q WHERE q.questionBank.questionBankId = :questionBankId")
+    Optional<Boolean> findIsRequiredByQuestionBankId(Long questionBankId);
 }

--- a/api/src/main/java/com/thesurvey/api/service/mapper/QuestionBankMapper.java
+++ b/api/src/main/java/com/thesurvey/api/service/mapper/QuestionBankMapper.java
@@ -8,12 +8,19 @@ import com.thesurvey.api.dto.response.question.QuestionBankAnswerDto;
 import com.thesurvey.api.dto.response.question.QuestionBankResponseDto;
 import com.thesurvey.api.dto.response.question.QuestionOptionAnswerDto;
 import com.thesurvey.api.dto.response.question.QuestionOptionResponseDto;
+import com.thesurvey.api.exception.ErrorMessage;
+import com.thesurvey.api.exception.mapper.NotFoundExceptionMapper;
+import com.thesurvey.api.repository.QuestionRepository;
 import com.thesurvey.api.util.StringUtil;
 
 import org.springframework.stereotype.Component;
 
 @Component
 public class QuestionBankMapper {
+
+    private final QuestionRepository questionRepository;
+
+    public QuestionBankMapper(QuestionRepository questionRepository) {this.questionRepository = questionRepository;}
 
     public QuestionBank toQuestionBank(QuestionRequestDto questionRequestDto) {
         return QuestionBank.builder()
@@ -25,10 +32,14 @@ public class QuestionBankMapper {
 
     public QuestionBankResponseDto toQuestionBankResponseDto(QuestionBank questionBank,
         List<QuestionOptionResponseDto> questionOptionResponseDtoList) {
+        Boolean isRequired = questionRepository.findIsRequiredByQuestionBankId(
+                questionBank.getQuestionBankId()).orElseThrow(
+                    () -> new NotFoundExceptionMapper(ErrorMessage.QUESTION_NOT_FOUND));
         return QuestionBankResponseDto.builder()
             .questionBankId(questionBank.getQuestionBankId())
             .title(questionBank.getTitle())
             .description(questionBank.getDescription())
+            .isRequired(isRequired)
             .questionType(questionBank.getQuestionType())
             .questionOptions(questionOptionResponseDtoList)
             .createdDate(questionBank.getCreatedDate())


### PR DESCRIPTION
이 PR에선 설문조사 정보 요청 시 응답으로 질문 마다 `isRequired`정보를 추가하는 일을 수행하였습니다.

**추가 사항**
- `QuestionBankId`로 `Question`테이블에서 `isRequired`를 조회하는 메소드 추가

**변경 사항**
- `QuestionBankResponseDto`에 `isRequired` 속성 추가