### PR TITLE
feature: 사용자 정보 조회 및 인증여부 조회 구현

### DIFF
--- a/web/src/api/axios.ts
+++ b/web/src/api/axios.ts
@@ -2,8 +2,11 @@ import axios, { AxiosError, AxiosInstance, AxiosResponse, InternalAxiosRequestCo
 
 const instance: AxiosInstance = axios.create({
   // baseURL: 'https://capstone-mock-api.fly.dev',
-  baseURL: 'http://localhost:8080/v1',
-  // baseURL: 'https://api.thesurvey.kr/v1',
+  // baseURL: 'http://localhost:8080/v1',
+
+  // FIXME: 원활한 thesurvey.kr 사용을 위한 Base url 변경,
+  // FIXME: 구현 및 테스트시 BaseUrl을 변경하여 사용할 것.
+  baseURL: 'https://api.thesurvey.kr/v1',
   // timeout: 15000,
   withCredentials: true,
 });

--- a/web/src/api/request.ts
+++ b/web/src/api/request.ts
@@ -47,6 +47,20 @@ export const requests = {
    */
   updateUserProfile: '/users/profile',
   /**
+   * Get Profile information of user certification list
+   *
+   * @method `GET`
+   * @endpoint `/users/profile/certifications`
+   */
+  getUserAuthList: '/users/profile/certifications',
+  /**
+   * Update profile information of user certification list
+   *
+   * @method `PATCH`
+   * @endpoint `/users/profile/certifications`
+   */
+  updateUserAuthList: '/users/profile/certifications',
+  /**
    * Delete currently signed in user. This requires user
    * to be signed in.
    *

--- a/web/src/components/Header.tsx
+++ b/web/src/components/Header.tsx
@@ -268,7 +268,7 @@ export default function Header({ theme, toggleTheme }: HeaderProps) {
           </CheckBoxWrapper>
 
           {currentLocation === '/mypage' || currentLocation === '/mypage/' ? (
-            <CustomButton theme={theme} onClick={() => navigate('../mypage')}>
+            <CustomButton theme={theme} onClick={updateUserInformation}>
               개인정보 저장하기
             </CustomButton>
           ) : undefined}

--- a/web/src/components/Header.tsx
+++ b/web/src/components/Header.tsx
@@ -192,7 +192,7 @@ const CustomButton = styled.div`
   padding: 1vh;
   font-size: 1.7vh;
   font-weight: 700;
-  color: ${(props) => props.theme.colors.default};
+  color: white;
   background-color: ${(props) => props.theme.colors.primary};
   border: none;
   border-radius: ${(props) => props.theme.borderRadius};

--- a/web/src/components/LoginForm.tsx
+++ b/web/src/components/LoginForm.tsx
@@ -97,7 +97,7 @@ interface LoginFormProps {
 export default function LoginForm({ theme }: LoginFormProps) {
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
-  const [isAlertModal, setIsAlertModal] = useState<boolean>(false);
+  const [showAlertModal, setShowAlertModal] = useState<boolean>(false);
   const [alertTitle, setAlertTitle] = useState('');
   const [alertText, setAlertText] = useState('');
   const dispatch = useDispatch();
@@ -107,7 +107,7 @@ export default function LoginForm({ theme }: LoginFormProps) {
     if (isEmptyString(email) || isEmptyString(password)) {
       setAlertTitle('로그인 오류');
       setAlertText('아이디 또는 비밀번호를 확인해주세요.');
-      setIsAlertModal(true);
+      setShowAlertModal(true);
       return false;
     }
     return true;
@@ -120,16 +120,26 @@ export default function LoginForm({ theme }: LoginFormProps) {
     }
 
     const loginRequestBody = { email, password };
-    const res = await axios.post<UserResponse>(requests.login, loginRequestBody);
-    if (res.status === 200) {
-      setUserInformation(res.data, password, dispatch);
-      dispatch(setLoggedIn(true));
-      navigate('../../');
-    }
+    axios
+      .post<UserResponse>(requests.login, loginRequestBody)
+      .then((res) => {
+        if (res.status === 200) {
+          setUserInformation(res.data, password, dispatch);
+          dispatch(setLoggedIn(true));
+          navigate('../../');
+        }
+      })
+      .catch((error) => {
+        if (error.request.status === 404) {
+          setAlertTitle('로그인 오류');
+          setAlertText('아이디 또는 비밀번호를 확인해주세요.');
+          setShowAlertModal(true);
+        }
+      });
   };
 
   const closeAlertModal = () => {
-    setIsAlertModal(false);
+    setShowAlertModal(false);
   };
 
   const handleSubmit = (event: React.FormEvent<HTMLFormElement>) => {
@@ -161,7 +171,7 @@ export default function LoginForm({ theme }: LoginFormProps) {
         <Button onClick={() => handleLogin()} theme={theme}>
           로그인
         </Button>
-        {isAlertModal && (
+        {showAlertModal && (
           <AlertModal
             theme={theme}
             title={alertTitle}

--- a/web/src/components/Modal/HeaderModal.tsx
+++ b/web/src/components/Modal/HeaderModal.tsx
@@ -4,9 +4,13 @@ import { useDispatch, useSelector } from 'react-redux';
 import { useNavigate } from 'react-router-dom';
 import styled, { DefaultTheme } from 'styled-components';
 
+import axios from '../../api/axios';
+import { requests } from '../../api/request';
 import { useOnClickOutside } from '../../hooks/useOnClickOutside';
 import { RootState } from '../../reducers';
 import { setLoggedIn, setSubPageOpen } from '../../types/header';
+import { UserAuthListResponse } from '../../types/response/User';
+import { initializeAuthList } from '../../utils/authService';
 import { clearUserInformation } from '../../utils/UserUtils';
 
 const SubPageContainer = styled.div`
@@ -62,9 +66,20 @@ export default function Header({ theme }: HeaderProps) {
     navigate('../../../');
   };
 
-  const navigateMypage = () => {
-    navigate('../../../mypage');
+  const navigateMypage = async () => {
     dispatch(setSubPageOpen(!isSubPageOpen));
+    axios
+      .get<UserAuthListResponse>(requests.getUserAuthList)
+      .then((getAuthListResponse) => {
+        if (getAuthListResponse.status === 200) {
+          console.log('getUserData Success!');
+          initializeAuthList(getAuthListResponse.data, dispatch);
+          navigate('../../../mypage');
+        }
+      })
+      .catch((error) => {
+        console.log(error);
+      });
   };
 
   const subPageRef = useRef<HTMLDivElement>(null);

--- a/web/src/reducers/form.ts
+++ b/web/src/reducers/form.ts
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import { RegisterFormState, RegisterFormAction } from '../types/registerForm';
 
 export const formReducer = (state: RegisterFormState, action: RegisterFormAction): RegisterFormState => {

--- a/web/src/routes/MyPages/AuthListPage.tsx
+++ b/web/src/routes/MyPages/AuthListPage.tsx
@@ -9,6 +9,7 @@ import Header from '../../components/Header';
 import { useTheme } from '../../hooks/useTheme';
 import { RootState } from '../../reducers';
 import { setAuthService } from '../../types/surveyAuth';
+import { updateUserInformation } from '../../utils/UserUtils';
 
 const KakaoImage = styled(Icons.KAKAO).attrs({
   width: 30,
@@ -205,20 +206,19 @@ export default function AuthListPage() {
     event.preventDefault();
   };
 
-  // FIXME: 인증과정 구현 후에 인증완료 버튼을 disabled 하기.
   return (
     <Container theme={theme}>
       <Header theme={theme} toggleTheme={toggleTheme} />
       <AuthListContainer theme={theme}>
         <Form onSubmit={handleSubmit}>
           <AuthListTitle theme={theme}>
-            <MypageText theme={theme} onClick={() => navigate('../mypage')}>
+            <MypageText theme={theme} onClick={() => updateUserInformation(dispatch, navigate)}>
               마이페이지
             </MypageText>
             <AuthInformationText theme={theme}> &gt; 인증정보 목록</AuthInformationText>
           </AuthListTitle>
           {surveyAuthList.map(({ number, image, title, checkAuth }) => (
-            <ContainerBox key={number} theme={theme} onClick={() => handleClick(title)}>
+            <ContainerBox key={number} theme={theme} onClick={() => handleClick(title)} disabled={checkAuth}>
               {image}
               <TextType
                 theme={theme}

--- a/web/src/routes/MyPages/AuthenticationPage.tsx
+++ b/web/src/routes/MyPages/AuthenticationPage.tsx
@@ -8,8 +8,7 @@ import { Icons } from '../../assets/svg/index';
 import Header from '../../components/Header';
 import { useTheme } from '../../hooks/useTheme';
 import { RootState } from '../../reducers';
-import { getKakaoUserData } from '../../utils/authlist/kakaoAuth';
-import { authConnect, authComplete } from '../../utils/authService';
+import { authConnect, authComplete, getApiUserInformation } from '../../utils/authService';
 
 const rotate = keyframes`
   0% {
@@ -99,11 +98,11 @@ export default function AuthenticationPage() {
   const urlParams = new URLSearchParams(window.location.search);
   const authCode = urlParams.get('code');
 
-  // 인가 코드가 오면 인증 상태 변경.
+  // 인가 코드가 오면 해당 인증사이트에서 가져온 사용자 개인정보 조회.
   useEffect(() => {
     if (authCode !== null) {
       // FIXME: 추가 인증방식을 도입할때 리팩토링 할 것.
-      getKakaoUserData(authCode, username, dispatch);
+      getApiUserInformation(checkAuthServiceTitle, authCode, username, dispatch);
     }
   }, [authCode]);
 
@@ -140,7 +139,7 @@ export default function AuthenticationPage() {
             {!connectService ? `${checkAuthServiceTitle}에서 인증을 완료해주세요.` : `인증 진행중 입니다.`}
           </TextType>
           {!connectService && (
-            <Button theme={theme} onClick={() => authConnect(checkAuthServiceTitle, setConnectService)}>
+            <Button theme={theme} onClick={() => authConnect(checkAuthServiceTitle, setConnectService, dispatch)}>
               인증하기
             </Button>
           )}

--- a/web/src/routes/MyPages/ProfilePage.tsx
+++ b/web/src/routes/MyPages/ProfilePage.tsx
@@ -146,7 +146,7 @@ const formatPhoneNumber = (value: string): string => {
   return phoneNumber;
 };
 
-export default function MyPage() {
+export default function ProfilePage() {
   const [theme, toggleTheme] = useTheme();
   const navigate = useNavigate();
   const [updatePasswordDisabled, setUpdatePasswordDisabled] = useState(false);

--- a/web/src/routes/MyPages/SurveyResultPage.tsx
+++ b/web/src/routes/MyPages/SurveyResultPage.tsx
@@ -1,11 +1,13 @@
 import React, { useState } from 'react';
 
+import { useDispatch } from 'react-redux';
 import { useNavigate } from 'react-router-dom';
 import styled from 'styled-components';
 
 import { Icons } from '../../assets/svg/index';
 import Header from '../../components/Header';
 import { useTheme } from '../../hooks/useTheme';
+import { updateUserInformation } from '../../utils/UserUtils';
 
 const TwoArrow = styled(Icons.TWOARROW).attrs({
   width: 24,
@@ -116,11 +118,12 @@ const FontText = styled.span`
   text-overflow: ellipsis;
 `;
 
-export default function MyPage() {
+export default function SurveyResultPage() {
   const [theme, toggleTheme] = useTheme();
   const [resultClickFirst, setResultClickFirst] = useState<boolean>(false);
   const [resultClickSecond, setResultClickSecond] = useState<boolean>(false);
   const navigate = useNavigate();
+  const dispatch = useDispatch();
 
   const handleSubmit = (event: React.FormEvent<HTMLFormElement>) => {
     event.preventDefault();
@@ -145,7 +148,7 @@ export default function MyPage() {
       <SurveyResultContainer theme={theme}>
         <Form onSubmit={handleSubmit}>
           <SurVeyResultPageTitle style={{ marginBottom: '5vh' }} theme={theme}>
-            <MypageText theme={theme} onClick={() => navigate('../mypage')}>
+            <MypageText theme={theme} onClick={() => updateUserInformation(dispatch, navigate)}>
               마이페이지
             </MypageText>
             <SurveyResultText theme={theme}> &gt; 설문 결과 조회</SurveyResultText>

--- a/web/src/types/request/User.ts
+++ b/web/src/types/request/User.ts
@@ -4,3 +4,12 @@ export interface UserUpdateRequest {
   address?: string;
   profileImage?: string;
 }
+
+export interface UserAuthListUpdateRequest {
+  isKakaoCertificated: boolean;
+  isNaverCertificated: boolean;
+  isGoogleCertificated: boolean;
+  isWebMailCertificated: boolean;
+  isDriverLicenseCertificated: boolean;
+  isIdentityCardCertificated: boolean;
+}

--- a/web/src/types/response/User.ts
+++ b/web/src/types/response/User.ts
@@ -8,3 +8,13 @@ export interface UserResponse extends BaseTime {
   address: string;
   profileImage: string;
 }
+
+export interface UserAuthListResponse extends UserAuthInformation {
+  certificationInfolist: Array<UserAuthInformation>;
+}
+
+export interface UserAuthInformation {
+  certificationName: string;
+  isCertificated: boolean;
+  expirationDate: Date | string;
+}

--- a/web/src/utils/UserUtils.ts
+++ b/web/src/utils/UserUtils.ts
@@ -1,5 +1,9 @@
 import { useDispatch } from 'react-redux';
+import { useNavigate } from 'react-router';
 
+import axios from '../api/axios';
+import { requests } from '../api/request';
+import { UserResponse } from '../types/response/User';
 import {
   setAuthDriver,
   setAuthGoogle,
@@ -25,13 +29,24 @@ import {
  * @param dispatch : Function for updating information on react-redux
  */
 export const setUserInformation = (userdata: any, password: string, dispatch = useDispatch()) => {
-  dispatch(setUserPoint('0'));
+  dispatch(setUserPoint(userdata.point === undefined ? '0' : userdata.point));
   dispatch(setUserEmail(userdata.email));
-  dispatch(setUserPassword(password));
+  if (password !== 'passwordUndefined') {
+    dispatch(setUserPassword(password));
+  }
   dispatch(setUserName(userdata.name));
   dispatch(setPhoneNumber(userdata.phoneNumber));
   dispatch(setUserAddress(userdata.address === null ? '주소를 입력해주세요' : userdata.address));
   dispatch(setUserProfileImage('https://images2.alphacoders.com/130/1306410.png'));
+};
+
+// 마이페이지 이동시 사용자 정보 조회 및 업데이트.
+export const updateUserInformation = async (dispatch = useDispatch(), navigate = useNavigate()) => {
+  const res = await axios.get<UserResponse>(requests.getUserProfile);
+  if (res.status === 200) {
+    setUserInformation(res.data, 'passwordUndefined', dispatch);
+    navigate('../../mypage');
+  }
 };
 
 // if we logout in this service, initialize userData in local.

--- a/web/src/utils/authService.ts
+++ b/web/src/utils/authService.ts
@@ -1,6 +1,9 @@
 import { useDispatch } from 'react-redux';
 import { useNavigate } from 'react-router-dom';
 
+import axios from '../api/axios';
+import { requests } from '../api/request';
+import { UserAuthListUpdateRequest } from '../types/request';
 import {
   setAuthKakao,
   setAuthGoogle,
@@ -12,11 +15,47 @@ import {
   setAuthService,
   setSuccessAuth,
 } from '../types/surveyAuth';
-import { KAKAO_AUTH_URL } from './authlist/kakaoAuth';
-import { NAVER_AUTH_URL } from './authlist/naverAuth';
+import { KAKAO_AUTH_URL, getKakaoUserData } from './authlist/kakaoAuth';
+import { NAVER_AUTH_URL, getNaverUserData } from './authlist/naverAuth';
+
+// 인증여부 초기화 - authlist api connect
+export const initializeAuthList = (resData: any, dispatch = useDispatch()) => {
+  if (resData.certificationInfolist !== null) {
+    for (let i = 0; i < resData.certificationInfoList.length; i += 1) {
+      const certicication = resData.certificationInfoList[i];
+      const name = certicication.certificationName;
+      const checkCertificated = certicication.isCertificated;
+      console.log('인증명 : ', name, '인증여부 : ', checkCertificated);
+      if (checkCertificated === true) {
+        switch (name) {
+          case 'KAKAO':
+            dispatch(setAuthKakao(true));
+            break;
+          case 'NAVER':
+            dispatch(setAuthNaver(true));
+            break;
+          case 'GOOGLE':
+            dispatch(setAuthGoogle(true));
+            break;
+          case 'IDENTITY_CARD':
+            dispatch(setAuthIdentity(true));
+            break;
+          case 'DRIVER_LICENSE':
+            dispatch(setAuthDriver(true));
+            break;
+          case 'WEBMAIL':
+            dispatch(setAuthWebMail(true));
+            break;
+          default:
+            break;
+        }
+      }
+    }
+  }
+};
 
 // FIXME: 다른 사용자 인증 과정 추가 구현하기.
-export const authConnect = (checkAuthServiceTitle: string, setConnectService: any) => {
+export const authConnect = (checkAuthServiceTitle: string, setConnectService: any, dispatch = useDispatch()) => {
   setConnectService(true);
   switch (checkAuthServiceTitle) {
     case '카카오':
@@ -25,6 +64,46 @@ export const authConnect = (checkAuthServiceTitle: string, setConnectService: an
     case '네이버':
       console.log('네이버 로그인');
       window.location.href = NAVER_AUTH_URL;
+      break;
+    case '구글':
+      dispatch(setSuccessAuth(true));
+      dispatch(setCompleteAuth(true));
+      break;
+    case '신분증':
+      dispatch(setSuccessAuth(true));
+      dispatch(setCompleteAuth(true));
+      break;
+    case '운전면허':
+      dispatch(setSuccessAuth(true));
+      dispatch(setCompleteAuth(true));
+      break;
+    case '웹메일':
+      dispatch(setSuccessAuth(true));
+      dispatch(setCompleteAuth(true));
+      break;
+    default:
+      break;
+  }
+};
+
+// FIXME: 추가 인증구현시 인증성공 과정을 수정.
+/**
+ * 인증사이트에서 로그인 성공시 개인정보를 조회하는 함수.
+ */
+export const getApiUserInformation = (
+  checkAuthServiceTitle: string,
+  authCode: string,
+  username: string,
+  dispatch = useDispatch()
+) => {
+  switch (checkAuthServiceTitle) {
+    case '카카오':
+      getKakaoUserData(authCode, username, dispatch);
+      break;
+    case '네이버':
+      // getNaverUserData(authCode, username, dispatch);
+      dispatch(setSuccessAuth(true));
+      dispatch(setCompleteAuth(true));
       break;
     case '구글':
       break;
@@ -39,41 +118,61 @@ export const authConnect = (checkAuthServiceTitle: string, setConnectService: an
   }
 };
 
-// 사용자 정보 조회가 일치하면 인증성공(완료) => 인증여부 변경.
-export const authComplete = (
+// 사용자 정보 조회가 일치하면 인증성공(완료) => 인증여부 변경 및 api connect
+export const authComplete = async (
   checkAuthServiceTitle: string,
   surveyAuthState: any,
   dispatch = useDispatch(),
   navigate = useNavigate()
 ) => {
+  const updateAuthListBody: UserAuthListUpdateRequest = {
+    isKakaoCertificated: surveyAuthState.kakao,
+    isNaverCertificated: surveyAuthState.naver,
+    isGoogleCertificated: surveyAuthState.google,
+    isWebMailCertificated: surveyAuthState.webmail,
+    isIdentityCardCertificated: surveyAuthState.identityCard,
+    isDriverLicenseCertificated: surveyAuthState.driverLicense,
+  };
+
   if (surveyAuthState.checkSuccessAuth) {
     switch (checkAuthServiceTitle) {
       case '카카오':
         dispatch(setAuthKakao(!surveyAuthState.kakao));
+        updateAuthListBody.isKakaoCertificated = !surveyAuthState.kakao;
         break;
       case '네이버':
         dispatch(setAuthNaver(!surveyAuthState.naver));
+        updateAuthListBody.isNaverCertificated = !surveyAuthState.naver;
         break;
       case '구글':
         dispatch(setAuthGoogle(!surveyAuthState.google));
+        updateAuthListBody.isGoogleCertificated = !surveyAuthState.google;
         break;
       case '신분증':
         dispatch(setAuthIdentity(!surveyAuthState.identityCard));
+        updateAuthListBody.isIdentityCardCertificated = !surveyAuthState.identityCard;
         break;
       case '운전면허':
         dispatch(setAuthDriver(!surveyAuthState.driverLicense));
+        updateAuthListBody.isDriverLicenseCertificated = !surveyAuthState.driverLicense;
         break;
       case '웹메일':
         dispatch(setAuthWebMail(!surveyAuthState.webmail));
+        updateAuthListBody.isWebMailCertificated = !surveyAuthState.webmail;
         break;
       default:
         break;
     }
   }
 
-  // 인증 후, 인증관련 데이터 변수 초기화.
+  // 인증 후, 인증관련 데이터 변수 초기화 및 인증 정보 업데이트
   dispatch(setCompleteAuth(false));
   dispatch(setSuccessAuth(false));
   dispatch(setAuthService(''));
   navigate('../mypage/auth-list');
+
+  const res = await axios.patch<UserAuthListUpdateRequest>(requests.updateUserAuthList, updateAuthListBody);
+  if (res.status === 200) {
+    console.log('getUserData Success!');
+  }
 };

--- a/web/src/utils/authlist/kakaoAuth.ts
+++ b/web/src/utils/authlist/kakaoAuth.ts
@@ -15,6 +15,18 @@ export const KAKAO_REST_API_KEY = '076bd4745b2957a7567361ad04b58a57';
 export const KAKAO_REDIRECT_URI = 'http://localhost:3000/mypage/authentication';
 export const KAKAO_AUTH_URL = `https://kauth.kakao.com/oauth/authorize?client_id=${KAKAO_REST_API_KEY}&redirect_uri=${KAKAO_REDIRECT_URI}&response_type=code`;
 
+// 다른 로그인 환경에 영향을 끼치는 것을 방지하기 위한 kakao token값 초기화
+export const unlinkKakao = async (kakaoToken: any) => {
+  const res = await axios({
+    method: 'POST',
+    url: `https://kapi.kakao.com/v1/user/unlink`,
+    headers: {
+      'Content-Type': 'application/x-www-form-urlencoded',
+      Authorization: `Bearer ${kakaoToken}`,
+    },
+  });
+};
+
 /**
  * 카카오 사용자 정보 조회를 위한 Function
  * @param kakaoToken : 카카오에서 받은 인자코드를 사용하여 받은 token값
@@ -33,11 +45,12 @@ export const getKakaoProfile = async (kakaoToken: any, username: string, dispatc
     console.log('kakaoUser name : ', name);
 
     if (name === username) {
-      console.log('사용자가 같습니다!');
+      console.log('카카오 인증 완료!');
       dispatch(setSuccessAuth(true));
     } else {
       console.log('사용자가 다릅니다!');
     }
+    unlinkKakao(kakaoToken);
     dispatch(setCompleteAuth(true));
   } catch (error) {
     console.log(error);


### PR DESCRIPTION
**1. 사용자 정보 조회 업데이트**
- 사용자 정보가 계속해서 업데이트가 될 수 있는 가능성이 있기 때문에 Mypage로 이동하는 모든 경로를 따로 함수로 만들어 사용자 정보 조회 데이터를 GET한다.
**2. 인증 정보 업데이트 및 조회를 위한 api-connecting**
- 인증 정보 조회는 MainPage -> MyPage로 navigate할 때, 사용자 정보와 함께 GET하여 redux 데이터로 저장한다.
- 인증 정보 업데이트는 모든 인증과정을 거치고 성공적으로 인증을 마친 상태에서 '돌아가기'ButtonClick할 때, 모든 인증 정보를 RequestBody로 생성하여 api로 데이터를 보낸다.
**3. 그 외 업데이트 사항**
- 헤더 버튼 색상 통일 
<img width="628" alt="image" src="https://github.com/kookmin-sw/capstone-2023-40/assets/68771488/895d7c40-1867-4b77-8433-c99474f41764">

- BaseURL 수정 : `https://api.thesurvey.kr/v1`,
- 원활한 [thesurvey.kr](http://thesurvey.kr/) 사용을 위한 Base url 변경, 앞으로는 프론트 구현 및 테스트 시 BaseUrl을 `http://localhost:8080/v1`변경하여 사용할 것.

- `feature/user-auth-api-connecting` branch에서 변경되어야 하는 사항들만 수정
closed #159