### PR TITLE
feat: 포인트 시스템 구현

### DIFF
--- a/api/src/main/java/com/thesurvey/api/controller/SurveyController.java
+++ b/api/src/main/java/com/thesurvey/api/controller/SurveyController.java
@@ -7,6 +7,7 @@ import javax.validation.Valid;
 import com.thesurvey.api.dto.request.answeredQuestion.AnsweredQuestionRequestDto;
 import com.thesurvey.api.dto.request.survey.SurveyRequestDto;
 import com.thesurvey.api.dto.request.survey.SurveyUpdateRequestDto;
+import com.thesurvey.api.dto.response.answeredQuestion.AnsweredQuestionRewardPointDto;
 import com.thesurvey.api.dto.response.survey.SurveyListPageDto;
 import com.thesurvey.api.dto.response.survey.SurveyResponseDto;
 import com.thesurvey.api.service.AnsweredQuestionService;
@@ -126,18 +127,19 @@ public class SurveyController {
 
     @Operation(summary = "설문조사 응답 제출", description = "설문조사 응답을 제출합니다.")
     @ApiResponses(value = {
-        @ApiResponse(responseCode = "204", description = "요청 성공"),
+        @ApiResponse(responseCode = "200", description = "요청 성공"),
         @ApiResponse(responseCode = "400", description = "잘못된 요청", content = @Content(schema = @Schema(hidden = true))),
         @ApiResponse(responseCode = "401", description = "사용자 인증 실패", content = @Content(schema = @Schema(hidden = true))),
         @ApiResponse(responseCode = "403", description = "접근 권한 없음", content = @Content(schema = @Schema(hidden = true))),
         @ApiResponse(responseCode = "404", description = "요청한 리소스 찾을 수 없음", content = @Content(schema = @Schema(hidden = true)))
     })
     @PostMapping("/submit")
-    public ResponseEntity<Void> submitSurvey(
+    public ResponseEntity<AnsweredQuestionRewardPointDto> submitSurvey(
         @Parameter(hidden = true) Authentication authentication,
         @Valid @RequestBody AnsweredQuestionRequestDto answeredQuestionRequestDto) {
-        answeredQuestionService.createAnswer(authentication, answeredQuestionRequestDto);
-        return ResponseEntity.status(HttpStatus.NO_CONTENT).build();
+        AnsweredQuestionRewardPointDto rewardPointDto =
+            answeredQuestionService.createAnswer(authentication, answeredQuestionRequestDto);
+        return ResponseEntity.ok(rewardPointDto);
     }
 
 }

--- a/api/src/main/java/com/thesurvey/api/domain/EnumTypeEntity.java
+++ b/api/src/main/java/com/thesurvey/api/domain/EnumTypeEntity.java
@@ -44,6 +44,28 @@ public class EnumTypeEntity {
         }
     }
 
+    public enum PointTransactionType {
+
+        SINGLE_CHOICE_REWARD(1),
+        SINGLE_CHOICE_CONSUME(2),
+
+        MULTIPLE_CHOICES_REWARD(2),
+        MULTIPLE_CHOICES_CONSUME(4),
+
+        SHORT_ANSWER_REWARD(2),
+        SHORT_ANSWER_CONSUME(4),
+
+        LONG_ANSWER_REWARD(3),
+        LONG_ANSWER_CONSUME(6);
+
+        @Getter
+        private final int transactionPoint;
+
+        PointTransactionType(int transactionPoint) {
+            this.transactionPoint = transactionPoint;
+        }
+    }
+
     public enum Role {
         USER,
         ADMIN

--- a/api/src/main/java/com/thesurvey/api/domain/PointHistory.java
+++ b/api/src/main/java/com/thesurvey/api/domain/PointHistory.java
@@ -38,6 +38,8 @@ public class PointHistory {
     @Column(name = "point")
     private Integer point;
 
+    public static final int USER_INITIAL_POINT = 50;
+
     @Builder
     public PointHistory(User user, LocalDateTime transactionDate, Integer point) {
         this.user = user;

--- a/api/src/main/java/com/thesurvey/api/dto/request/answeredQuestion/AnsweredQuestionDto.java
+++ b/api/src/main/java/com/thesurvey/api/dto/request/answeredQuestion/AnsweredQuestionDto.java
@@ -2,9 +2,11 @@ package com.thesurvey.api.dto.request.answeredQuestion;
 
 import java.util.List;
 
+import javax.validation.constraints.NotNull;
 import javax.validation.constraints.Positive;
 import javax.validation.constraints.Size;
 
+import com.thesurvey.api.domain.EnumTypeEntity.QuestionType;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
 import lombok.Getter;
@@ -13,8 +15,17 @@ import lombok.Getter;
 @Builder
 public class AnsweredQuestionDto {
 
+    @NotNull
     @Schema(example = "1", description = "응답하려는 설문은행 아이디입니다.")
     private Long questionBankId;
+
+    @NotNull
+    @Schema(example = "true", description = "답변한 질문의 필수 질문 여부입니다.")
+    private Boolean isRequired;
+
+    @NotNull
+    @Schema(example = "SINGLE_CHOICE", description = "답변한 질문 유형입니다.")
+    private QuestionType questionType;
 
     @Positive
     @Schema(example = "2", description = "응답하려는 단일 선택 항목의 번호입니다.")

--- a/api/src/main/java/com/thesurvey/api/dto/request/answeredQuestion/AnsweredQuestionRequestDto.java
+++ b/api/src/main/java/com/thesurvey/api/dto/request/answeredQuestion/AnsweredQuestionRequestDto.java
@@ -7,7 +7,6 @@ import javax.validation.Valid;
 import javax.validation.constraints.NotEmpty;
 import javax.validation.constraints.NotNull;
 
-import com.thesurvey.api.domain.EnumTypeEntity.CertificationType;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
 import lombok.Getter;

--- a/api/src/main/java/com/thesurvey/api/dto/response/answeredQuestion/AnsweredQuestionRewardPointDto.java
+++ b/api/src/main/java/com/thesurvey/api/dto/response/answeredQuestion/AnsweredQuestionRewardPointDto.java
@@ -1,0 +1,12 @@
+package com.thesurvey.api.dto.response.answeredQuestion;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class AnsweredQuestionRewardPointDto {
+
+    private int rewardPoints;
+
+}

--- a/api/src/main/java/com/thesurvey/api/dto/response/survey/SurveyPageDto.java
+++ b/api/src/main/java/com/thesurvey/api/dto/response/survey/SurveyPageDto.java
@@ -45,5 +45,7 @@ public class SurveyPageDto {
     @JsonFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss")
     private LocalDateTime modifiedDate;
 
+    @Schema(example = "1", description = "설문조사 완료시 획득할 수 있는 포인트입니다.")
+    private Integer rewardPoints;
 
 }

--- a/api/src/main/java/com/thesurvey/api/dto/response/survey/SurveyResponseDto.java
+++ b/api/src/main/java/com/thesurvey/api/dto/response/survey/SurveyResponseDto.java
@@ -1,13 +1,12 @@
 package com.thesurvey.api.dto.response.survey;
 
-import com.thesurvey.api.dto.response.question.QuestionBankResponseDto;
-
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.UUID;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
 import com.thesurvey.api.domain.EnumTypeEntity.CertificationType;
+import com.thesurvey.api.dto.response.question.QuestionBankResponseDto;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
 import lombok.Getter;
@@ -48,5 +47,8 @@ public class SurveyResponseDto {
 
     @Schema(example = "[\"NAVER\", \"KAKAO\"]", description = "생성된 설문조사의 필수인증 목록입니다.")
     private List<CertificationType> certificationTypes;
+
+    @Schema(example = "1", description = "설문조사 완료시 획득할 수 있는 포인트입니다.")
+    private Integer rewardPoints;
 
 }

--- a/api/src/main/java/com/thesurvey/api/dto/response/user/UserResponseDto.java
+++ b/api/src/main/java/com/thesurvey/api/dto/response/user/UserResponseDto.java
@@ -42,6 +42,6 @@ public class UserResponseDto {
     private LocalDateTime modifiedDate;
 
     @Schema(example = "4", description = "사용자가 보유한 포인트입니다.")
-    private Integer userPoint;
+    private Integer userPoints;
 
 }

--- a/api/src/main/java/com/thesurvey/api/dto/response/user/UserResponseDto.java
+++ b/api/src/main/java/com/thesurvey/api/dto/response/user/UserResponseDto.java
@@ -42,6 +42,6 @@ public class UserResponseDto {
     private LocalDateTime modifiedDate;
 
     @Schema(example = "4", description = "사용자가 보유한 포인트입니다.")
-    private Integer userPoints;
+    private Integer point;
 
 }

--- a/api/src/main/java/com/thesurvey/api/dto/response/user/UserResponseDto.java
+++ b/api/src/main/java/com/thesurvey/api/dto/response/user/UserResponseDto.java
@@ -41,4 +41,7 @@ public class UserResponseDto {
     @JsonFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss")
     private LocalDateTime modifiedDate;
 
+    @Schema(example = "4", description = "사용자가 보유한 포인트입니다.")
+    private Integer userPoint;
+
 }

--- a/api/src/main/java/com/thesurvey/api/exception/ErrorMessage.java
+++ b/api/src/main/java/com/thesurvey/api/exception/ErrorMessage.java
@@ -26,7 +26,9 @@ public enum ErrorMessage {
     NOT_SURVEY_QUESTION("해당 설문조사의 질문이 아닙니다."),
     INVALID_REQUEST("유효하지 않은 요청입니다"),
     PAGE_NOT_FOUND("존재하지 않는 페이지입니다."),
-    CERTIFICATION_NOT_COMPLETED("설문조사에 필요한 인증을 하지 않았습니다.");
+    CERTIFICATION_NOT_COMPLETED("설문조사에 필요한 인증을 하지 않았습니다."),
+    SURVEY_CREATE_POINT_NOT_ENOUGH("설문조사 생성에 필요한 포인트가 부족합니다."),
+    INVALID_QUESTION_TYPE("유효하지 않은 질문 유형 입니다.");
 
     private final String message;
 

--- a/api/src/main/java/com/thesurvey/api/exception/ErrorMessage.java
+++ b/api/src/main/java/com/thesurvey/api/exception/ErrorMessage.java
@@ -16,7 +16,7 @@ public enum ErrorMessage {
     QUESTION_NOT_FOUND("존재하지 않는 설문조사 또는 질문입니다."),
     SURVEY_ALREADY_STARTED("이미 시작된 설문조사입니다."),
     ANSWER_ALREADY_SUBMITTED("이미 완료한 설문조사 입니다."),
-    NO_ANSWER_TO_QUESTION("질문에 응답을 하지 않았습니다."),
+    NOT_ANSWER_TO_REQUIRED_QUESTION("필수 질문에 응답을 하지 않았습니다."),
     STARTEDDATE_ISAFTER_ENDEDDATE("설문조사 시작 시간이 종료 시간보다 앞설 수 없습니다."),
     SURVEY_ALREADY_ENDED("이미 종료된 설문조사 입니다."),
     SURVEY_NOT_STARTED("아직 시작하지 않은 설문조사 입니다."),
@@ -28,7 +28,8 @@ public enum ErrorMessage {
     PAGE_NOT_FOUND("존재하지 않는 페이지입니다."),
     CERTIFICATION_NOT_COMPLETED("설문조사에 필요한 인증을 하지 않았습니다."),
     SURVEY_CREATE_POINT_NOT_ENOUGH("설문조사 생성에 필요한 포인트가 부족합니다."),
-    INVALID_QUESTION_TYPE("유효하지 않은 질문 유형 입니다.");
+    INVALID_QUESTION_TYPE("유효하지 않은 질문 유형 입니다."),
+    ANSWER_AT_LEAST_ONE_QUESTION("적어도 하나 이상의 질문에 답변을 해야합니다.");
 
     private final String message;
 

--- a/api/src/main/java/com/thesurvey/api/repository/PointHistoryRepository.java
+++ b/api/src/main/java/com/thesurvey/api/repository/PointHistoryRepository.java
@@ -1,0 +1,19 @@
+package com.thesurvey.api.repository;
+
+import java.util.List;
+
+import com.thesurvey.api.domain.PointHistory;
+import com.thesurvey.api.domain.PointHistoryId;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface PointHistoryRepository extends JpaRepository<PointHistory, PointHistoryId> {
+
+    @Query(value = "SELECT ph.point FROM PointHistory ph WHERE ph.user.userId = :userId ORDER BY "
+        + "ph.transactionDate DESC")
+    List<Integer> findPointHistoryByUserId(@Param("userId") Long userId);
+}

--- a/api/src/main/java/com/thesurvey/api/repository/QuestionBankRepository.java
+++ b/api/src/main/java/com/thesurvey/api/repository/QuestionBankRepository.java
@@ -15,7 +15,8 @@ public interface QuestionBankRepository extends JpaRepository<QuestionBank, Long
 
     Optional<QuestionBank> findByQuestionBankId(Long questionBankId);
 
-    @Query("SELECT qb FROM QuestionBank qb JOIN FETCH qb.questions q JOIN q.survey s WHERE q.questionId.surveyId= :surveyId")
+    @Query("SELECT qb FROM QuestionBank qb JOIN FETCH qb.questions q JOIN q.survey s WHERE q"
+        + ".questionId.surveyId= :surveyId ORDER BY q.questionNo ASC")
     List<QuestionBank> findAllBySurveyId(UUID surveyId);
 
     @Query("SELECT qb FROM QuestionBank qb JOIN FETCH qb.questions q JOIN q.survey s WHERE q.questionId.surveyId = :surveyId AND qb.title = :title")

--- a/api/src/main/java/com/thesurvey/api/repository/SurveyRepository.java
+++ b/api/src/main/java/com/thesurvey/api/repository/SurveyRepository.java
@@ -28,4 +28,7 @@ public interface SurveyRepository extends JpaRepository<Survey, UUID> {
     @Query("SELECT new com.thesurvey.api.dto.response.user.UserSurveyTitleDto(s.surveyId, s.title) FROM Survey s WHERE s.authorId = :authorId ORDER BY s.createdDate DESC")
     List<UserSurveyTitleDto> findUserCreatedSurveysByAuthorID(@Param("authorId") Long authorId);
 
+    @Query("SELECT p.certificationType FROM Participation p WHERE p.survey.surveyId = :surveyId AND p.user.userId = :authorId")
+    List<Integer> findCertificationTypeBySurveyIdAndAuthorId(UUID surveyId, Long authorId);
+
 }

--- a/api/src/main/java/com/thesurvey/api/repository/SurveyRepository.java
+++ b/api/src/main/java/com/thesurvey/api/repository/SurveyRepository.java
@@ -28,7 +28,4 @@ public interface SurveyRepository extends JpaRepository<Survey, UUID> {
     @Query("SELECT new com.thesurvey.api.dto.response.user.UserSurveyTitleDto(s.surveyId, s.title) FROM Survey s WHERE s.authorId = :authorId ORDER BY s.createdDate DESC")
     List<UserSurveyTitleDto> findUserCreatedSurveysByAuthorID(@Param("authorId") Long authorId);
 
-    @Query("SELECT p.certificationType FROM Participation p WHERE p.survey.surveyId = :surveyId AND p.user.userId = :authorId")
-    List<Integer> findCertificationTypeBySurveyIdAndAuthorId(UUID surveyId, Long authorId);
-
 }

--- a/api/src/main/java/com/thesurvey/api/service/AnsweredQuestionService.java
+++ b/api/src/main/java/com/thesurvey/api/service/AnsweredQuestionService.java
@@ -14,6 +14,7 @@ import com.thesurvey.api.domain.Survey;
 import com.thesurvey.api.domain.User;
 import com.thesurvey.api.dto.request.answeredQuestion.AnsweredQuestionDto;
 import com.thesurvey.api.dto.request.answeredQuestion.AnsweredQuestionRequestDto;
+import com.thesurvey.api.dto.response.answeredQuestion.AnsweredQuestionRewardPointDto;
 import com.thesurvey.api.exception.ErrorMessage;
 import com.thesurvey.api.exception.mapper.BadRequestExceptionMapper;
 import com.thesurvey.api.exception.mapper.ForbiddenRequestExceptionMapper;
@@ -26,6 +27,8 @@ import com.thesurvey.api.repository.SurveyRepository;
 import com.thesurvey.api.repository.UserCertificationRepository;
 import com.thesurvey.api.service.converter.CertificationTypeConverter;
 import com.thesurvey.api.service.mapper.AnsweredQuestionMapper;
+import com.thesurvey.api.util.PointUtil;
+import com.thesurvey.api.util.StringUtil;
 import com.thesurvey.api.util.UserUtil;
 
 import org.springframework.security.core.Authentication;
@@ -51,12 +54,16 @@ public class AnsweredQuestionService {
 
     private final CertificationTypeConverter certificationTypeConverter;
 
+    private final PointHistoryService pointHistoryService;
+
+    private final PointUtil pointUtil;
+
     public AnsweredQuestionService(SurveyRepository surveyRepository,
         AnsweredQuestionRepository answeredQuestionRepository,
         QuestionBankRepository questionBankRepository,
         AnsweredQuestionMapper answeredQuestionMapper,
         QuestionRepository questionRepository,
-        ParticipationService participationService, UserCertificationRepository userCertificationRepository, CertificationTypeConverter certificationTypeConverter) {
+        ParticipationService participationService, UserCertificationRepository userCertificationRepository, CertificationTypeConverter certificationTypeConverter, PointHistoryService pointHistoryService, PointUtil pointUtil) {
         this.surveyRepository = surveyRepository;
         this.answeredQuestionRepository = answeredQuestionRepository;
         this.questionBankRepository = questionBankRepository;
@@ -65,6 +72,8 @@ public class AnsweredQuestionService {
         this.participationService = participationService;
         this.userCertificationRepository = userCertificationRepository;
         this.certificationTypeConverter = certificationTypeConverter;
+        this.pointHistoryService = pointHistoryService;
+        this.pointUtil = pointUtil;
     }
 
     @Transactional
@@ -83,7 +92,7 @@ public class AnsweredQuestionService {
     }
 
     @Transactional
-    public void createAnswer(Authentication authentication,
+    public AnsweredQuestionRewardPointDto createAnswer(Authentication authentication,
         AnsweredQuestionRequestDto answeredQuestionRequestDto) {
         User user = UserUtil.getUserFromAuthentication(authentication);
         Survey survey = surveyRepository.findBySurveyId(answeredQuestionRequestDto.getSurveyId())
@@ -99,8 +108,11 @@ public class AnsweredQuestionService {
         validateUserCompletedCertification(surveyCertificationList, user.getUserId());
         validateCreateAnswerRequest(user, survey);
 
+        int rewardPoints = 0;
         for (AnsweredQuestionDto answeredQuestionDto : answeredQuestionRequestDto.getAnswers()) {
-            validateEmptyAnswer(answeredQuestionDto);
+            if (answeredQuestionDto.getIsRequired() && validateEmptyAnswer(answeredQuestionDto)) {
+                throw new BadRequestExceptionMapper(ErrorMessage.NO_ANSWER_TO_QUESTION);
+            }
 
             QuestionBank questionBank = questionBankRepository.findByQuestionBankId(
                 answeredQuestionDto.getQuestionBankId()).orElseThrow(
@@ -128,11 +140,15 @@ public class AnsweredQuestionService {
 
                 answeredQuestionRepository.saveAll(answeredQuestionList);
             }
+            rewardPoints += getQuestionBankRewardPoints(answeredQuestionDto);
 
-            List<CertificationType> certificationTypeList =
-                getCertificationTypeList(surveyCertificationList);
-            participationService.createParticipation(user, certificationTypeList, survey);
         }
+        List<CertificationType> certificationTypeList =
+            getCertificationTypeList(surveyCertificationList);
+        participationService.createParticipation(user, certificationTypeList, survey);
+        pointHistoryService.savePointHistory(user, rewardPoints);
+
+        return AnsweredQuestionRewardPointDto.builder().rewardPoints(rewardPoints).build();
     }
 
     @Transactional
@@ -165,15 +181,15 @@ public class AnsweredQuestionService {
         }
     }
 
-    private void validateEmptyAnswer(AnsweredQuestionDto answeredQuestionDto) {
-        if (answeredQuestionDto.getLongAnswer() == null
-            && answeredQuestionDto.getShortAnswer() == null
+    private boolean validateEmptyAnswer(AnsweredQuestionDto answeredQuestionDto) {
+        return (answeredQuestionDto.getLongAnswer() == null
+            || StringUtil.trimShortLongAnswer(answeredQuestionDto.getLongAnswer(),
+            answeredQuestionDto.getIsRequired()).isEmpty())
+            && (answeredQuestionDto.getShortAnswer() == null
+            || StringUtil.trimShortLongAnswer(answeredQuestionDto.getShortAnswer(),
+            answeredQuestionDto.getIsRequired()).isEmpty())
             && answeredQuestionDto.getSingleChoice() == null
-            && (answeredQuestionDto.getMultipleChoices() == null
-            || answeredQuestionDto.getMultipleChoices().isEmpty())
-        ) {
-            throw new BadRequestExceptionMapper(ErrorMessage.NO_ANSWER_TO_QUESTION);
-        }
+            && (answeredQuestionDto.getMultipleChoices() == null || answeredQuestionDto.getMultipleChoices().isEmpty());
     }
 
     // validate if the user has completed the necessary certifications for the survey
@@ -194,4 +210,16 @@ public class AnsweredQuestionService {
         }
         return certificationTypeConverter.toCertificationTypeList(surveyCertificationList);
     }
+
+    private int getQuestionBankRewardPoints(AnsweredQuestionDto answeredQuestionDto) {
+        int rewardPoints = 0;
+        if (answeredQuestionDto.getIsRequired()) {
+            rewardPoints = pointUtil.calculateSurveyMaxRewardPoints(answeredQuestionDto.getQuestionType());
+        }
+        else if (!validateEmptyAnswer(answeredQuestionDto)) {
+            rewardPoints = pointUtil.calculateSurveyMaxRewardPoints(answeredQuestionDto.getQuestionType());
+        }
+        return rewardPoints;
+    }
+
 }

--- a/api/src/main/java/com/thesurvey/api/service/AuthenticationService.java
+++ b/api/src/main/java/com/thesurvey/api/service/AuthenticationService.java
@@ -1,5 +1,9 @@
 package com.thesurvey.api.service;
 
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+
+import com.thesurvey.api.domain.PointHistory;
 import com.thesurvey.api.domain.User;
 import com.thesurvey.api.dto.request.user.UserLoginRequestDto;
 import com.thesurvey.api.dto.request.user.UserRegisterRequestDto;
@@ -7,6 +11,7 @@ import com.thesurvey.api.dto.response.user.UserResponseDto;
 import com.thesurvey.api.exception.ErrorMessage;
 import com.thesurvey.api.exception.mapper.BadRequestExceptionMapper;
 import com.thesurvey.api.exception.mapper.UnauthorizedRequestExceptionMapper;
+import com.thesurvey.api.repository.PointHistoryRepository;
 import com.thesurvey.api.repository.UserRepository;
 import com.thesurvey.api.service.mapper.UserMapper;
 
@@ -32,12 +37,15 @@ public class AuthenticationService {
 
     private final UserMapper userMapper;
 
+    private final PointHistoryRepository pointHistoryRepository;
+
     public AuthenticationService(UserDetailsService userDetailsService,
-        UserService userService, UserRepository userRepository, UserMapper userMapper) {
+        UserService userService, UserRepository userRepository, UserMapper userMapper, PointHistoryRepository pointHistoryRepository) {
         this.userDetailsService = userDetailsService;
         this.userService = userService;
         this.userRepository = userRepository;
         this.userMapper = userMapper;
+        this.pointHistoryRepository = pointHistoryRepository;
     }
 
     public Authentication authenticate(Authentication authentication)
@@ -54,6 +62,13 @@ public class AuthenticationService {
     @Transactional
     public UserResponseDto register(UserRegisterRequestDto userRegisterRequestDto) {
         User user = userRepository.save(userMapper.toUser(userRegisterRequestDto));
+        pointHistoryRepository.save(
+            PointHistory.builder()
+                .user(user)
+                .point(PointHistory.USER_INITIAL_POINT)
+                .transactionDate(LocalDateTime.now(ZoneId.of("Asia/Seoul")))
+                .build()
+        );
         return userMapper.toUserResponseDto(user);
     }
 

--- a/api/src/main/java/com/thesurvey/api/service/PointHistoryService.java
+++ b/api/src/main/java/com/thesurvey/api/service/PointHistoryService.java
@@ -17,13 +17,13 @@ public class PointHistoryService {
 
     public PointHistoryService(PointHistoryRepository pointHistoryRepository) {this.pointHistoryRepository = pointHistoryRepository;}
 
-    public void savePointHistory(User user, int saveUserPoint) {
+    public void savePointHistory(User user, int operandPoint) {
         int userTotalPoint = getUserTotalPoint(user.getUserId());
         pointHistoryRepository.save(
             PointHistory.builder()
                 .user(user)
                 .transactionDate(LocalDateTime.now(ZoneId.of("Asia/Seoul")))
-                .point(userTotalPoint + saveUserPoint)
+                .point(userTotalPoint + operandPoint)
                 .build()
         );
     }

--- a/api/src/main/java/com/thesurvey/api/service/PointHistoryService.java
+++ b/api/src/main/java/com/thesurvey/api/service/PointHistoryService.java
@@ -1,0 +1,36 @@
+package com.thesurvey.api.service;
+
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.util.List;
+
+import com.thesurvey.api.domain.PointHistory;
+import com.thesurvey.api.domain.User;
+import com.thesurvey.api.repository.PointHistoryRepository;
+
+import org.springframework.stereotype.Service;
+
+@Service
+public class PointHistoryService {
+
+    private final PointHistoryRepository pointHistoryRepository;
+
+    public PointHistoryService(PointHistoryRepository pointHistoryRepository) {this.pointHistoryRepository = pointHistoryRepository;}
+
+    public void savePointHistory(User user, int saveUserPoint) {
+        int userTotalPoint = getUserTotalPoint(user.getUserId());
+        pointHistoryRepository.save(
+            PointHistory.builder()
+                .user(user)
+                .transactionDate(LocalDateTime.now(ZoneId.of("Asia/Seoul")))
+                .point(userTotalPoint + saveUserPoint)
+                .build()
+        );
+    }
+
+    public Integer getUserTotalPoint(Long userId) {
+        List<Integer> totalPoint = pointHistoryRepository.findPointHistoryByUserId(userId);
+        return totalPoint.get(0);
+    }
+
+}

--- a/api/src/main/java/com/thesurvey/api/service/QuestionService.java
+++ b/api/src/main/java/com/thesurvey/api/service/QuestionService.java
@@ -10,7 +10,6 @@ import com.thesurvey.api.domain.QuestionOption;
 import com.thesurvey.api.domain.Survey;
 import com.thesurvey.api.dto.request.question.QuestionBankUpdateRequestDto;
 import com.thesurvey.api.dto.request.question.QuestionRequestDto;
-import com.thesurvey.api.dto.request.survey.SurveyRequestDto;
 import com.thesurvey.api.dto.response.question.QuestionBankResponseDto;
 import com.thesurvey.api.dto.response.question.QuestionOptionResponseDto;
 import com.thesurvey.api.exception.ErrorMessage;
@@ -89,8 +88,8 @@ public class QuestionService {
     }
 
     @Transactional
-    public void createQuestion(SurveyRequestDto surveyRequestDto, Survey survey) {
-        for (QuestionRequestDto questionRequestDto : surveyRequestDto.getQuestions()) {
+    public void createQuestion(List<QuestionRequestDto> questionRequestDtoList, Survey survey) {
+        for (QuestionRequestDto questionRequestDto : questionRequestDtoList) {
             QuestionBank questionBank = questionBankRepository.save(
                 questionBankMapper.toQuestionBank(questionRequestDto));
 

--- a/api/src/main/java/com/thesurvey/api/service/mapper/AnsweredQuestionMapper.java
+++ b/api/src/main/java/com/thesurvey/api/service/mapper/AnsweredQuestionMapper.java
@@ -20,8 +20,10 @@ public class AnsweredQuestionMapper {
             .survey(survey)
             .questionBank(questionBank)
             .singleChoice(answeredQuestionRequestDto.getSingleChoice())
-            .shortAnswer(StringUtil.trim(answeredQuestionRequestDto.getShortAnswer()))
-            .longAnswer(StringUtil.trim(answeredQuestionRequestDto.getLongAnswer()))
+            .shortAnswer(StringUtil.trimShortLongAnswer(answeredQuestionRequestDto.getShortAnswer(),
+                answeredQuestionRequestDto.getIsRequired()))
+            .longAnswer(StringUtil.trimShortLongAnswer(answeredQuestionRequestDto.getLongAnswer(),
+                answeredQuestionRequestDto.getIsRequired()))
             .build();
     }
 

--- a/api/src/main/java/com/thesurvey/api/service/mapper/QuestionBankMapper.java
+++ b/api/src/main/java/com/thesurvey/api/service/mapper/QuestionBankMapper.java
@@ -32,9 +32,7 @@ public class QuestionBankMapper {
 
     public QuestionBankResponseDto toQuestionBankResponseDto(QuestionBank questionBank,
         List<QuestionOptionResponseDto> questionOptionResponseDtoList) {
-        Boolean isRequired = questionRepository.findIsRequiredByQuestionBankId(
-                questionBank.getQuestionBankId()).orElseThrow(
-                    () -> new NotFoundExceptionMapper(ErrorMessage.QUESTION_NOT_FOUND));
+        Boolean isRequired = getIsRequiredByQuestionBankId(questionBank.getQuestionBankId());
         return QuestionBankResponseDto.builder()
             .questionBankId(questionBank.getQuestionBankId())
             .title(questionBank.getTitle())
@@ -60,4 +58,10 @@ public class QuestionBankMapper {
             .optionAnswers(questionOptionAnswerDtoList)
             .build();
     }
+
+    private Boolean getIsRequiredByQuestionBankId(Long questionBankId) {
+        return questionRepository.findIsRequiredByQuestionBankId(questionBankId)
+            .orElseThrow(() -> new NotFoundExceptionMapper(ErrorMessage.QUESTION_NOT_FOUND));
+    }
+
 }

--- a/api/src/main/java/com/thesurvey/api/service/mapper/SurveyMapper.java
+++ b/api/src/main/java/com/thesurvey/api/service/mapper/SurveyMapper.java
@@ -16,6 +16,7 @@ import com.thesurvey.api.dto.response.user.UserSurveyResultDto;
 import com.thesurvey.api.repository.SurveyRepository;
 import com.thesurvey.api.service.QuestionService;
 import com.thesurvey.api.service.converter.CertificationTypeConverter;
+import com.thesurvey.api.util.PointUtil;
 import com.thesurvey.api.util.StringUtil;
 
 import org.springframework.data.domain.Page;
@@ -30,17 +31,21 @@ public class SurveyMapper {
 
     private final CertificationTypeConverter certificationTypeConverter;
 
+    private final PointUtil pointUtil;
+
+
     public SurveyMapper(SurveyRepository surveyRepository, QuestionService questionService,
-        CertificationTypeConverter certificationTypeConverter) {
+        CertificationTypeConverter certificationTypeConverter, PointUtil pointUtil) {
         this.surveyRepository = surveyRepository;
         this.questionService = questionService;
         this.certificationTypeConverter = certificationTypeConverter;
+        this.pointUtil = pointUtil;
     }
 
     public SurveyResponseDto toSurveyResponseDto(Survey survey, Long authorId) {
+        int maxRewardPoints = pointUtil.getSurveyMaxRewardPoints(survey.getSurveyId());
         List<QuestionBankResponseDto> questionBankResponseDtoList = questionService.getQuestionBankInfoDtoListBySurveyId(
             survey.getSurveyId());
-
         return SurveyResponseDto.builder()
             .surveyId(survey.getSurveyId())
             .authorId(authorId)
@@ -52,6 +57,7 @@ public class SurveyMapper {
             .modifiedDate(survey.getModifiedDate())
             .certificationTypes(getConvertedCertificationTypes(survey.getSurveyId(), survey.getAuthorId()))
             .questions(questionBankResponseDtoList)
+            .rewardPoints(maxRewardPoints)
             .build();
     }
 
@@ -67,6 +73,7 @@ public class SurveyMapper {
     }
 
     public SurveyPageDto toSurveyPageDto(Survey survey) {
+        int maxRewardPoints = pointUtil.getSurveyMaxRewardPoints(survey.getSurveyId());
         return SurveyPageDto.builder()
             .surveyId(survey.getSurveyId())
             .authorId(survey.getAuthorId())
@@ -77,6 +84,7 @@ public class SurveyMapper {
             .endedDate(survey.getEndedDate())
             .certificationTypes(getConvertedCertificationTypes(survey.getSurveyId(), survey.getAuthorId()))
             .modifiedDate(survey.getModifiedDate())
+            .rewardPoints(maxRewardPoints)
             .build();
     }
 

--- a/api/src/main/java/com/thesurvey/api/service/mapper/UserMapper.java
+++ b/api/src/main/java/com/thesurvey/api/service/mapper/UserMapper.java
@@ -41,7 +41,7 @@ public class UserMapper {
             .profileImage(user.getProfileImage())
             .createdDate(user.getCreatedDate())
             .modifiedDate(user.getModifiedDate())
-            .userPoints(pointHistoryService.getUserTotalPoint(user.getUserId()))
+            .point(pointHistoryService.getUserTotalPoint(user.getUserId()))
             .build();
     }
 

--- a/api/src/main/java/com/thesurvey/api/service/mapper/UserMapper.java
+++ b/api/src/main/java/com/thesurvey/api/service/mapper/UserMapper.java
@@ -3,6 +3,7 @@ package com.thesurvey.api.service.mapper;
 import com.thesurvey.api.domain.User;
 import com.thesurvey.api.dto.request.user.UserRegisterRequestDto;
 import com.thesurvey.api.dto.response.user.UserResponseDto;
+import com.thesurvey.api.service.PointHistoryService;
 import com.thesurvey.api.util.StringUtil;
 
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
@@ -11,6 +12,11 @@ import org.springframework.stereotype.Component;
 
 @Component
 public class UserMapper {
+    private final PointHistoryService pointHistoryService;
+
+    public UserMapper(PointHistoryService pointHistoryService) {
+        this.pointHistoryService = pointHistoryService;
+    }
 
     public User toUser(UserRegisterRequestDto userRegisterRequestDto) {
         return User
@@ -35,6 +41,7 @@ public class UserMapper {
             .profileImage(user.getProfileImage())
             .createdDate(user.getCreatedDate())
             .modifiedDate(user.getModifiedDate())
+            .userPoint(pointHistoryService.getUserTotalPoint(user.getUserId()))
             .build();
     }
 

--- a/api/src/main/java/com/thesurvey/api/service/mapper/UserMapper.java
+++ b/api/src/main/java/com/thesurvey/api/service/mapper/UserMapper.java
@@ -41,7 +41,7 @@ public class UserMapper {
             .profileImage(user.getProfileImage())
             .createdDate(user.getCreatedDate())
             .modifiedDate(user.getModifiedDate())
-            .userPoint(pointHistoryService.getUserTotalPoint(user.getUserId()))
+            .userPoints(pointHistoryService.getUserTotalPoint(user.getUserId()))
             .build();
     }
 

--- a/api/src/main/java/com/thesurvey/api/util/PointUtil.java
+++ b/api/src/main/java/com/thesurvey/api/util/PointUtil.java
@@ -1,0 +1,98 @@
+package com.thesurvey.api.util;
+
+import java.util.List;
+import java.util.UUID;
+
+import com.thesurvey.api.domain.EnumTypeEntity.QuestionType;
+import com.thesurvey.api.domain.QuestionBank;
+import com.thesurvey.api.exception.ErrorMessage;
+import com.thesurvey.api.exception.mapper.BadRequestExceptionMapper;
+import com.thesurvey.api.repository.QuestionBankRepository;
+import com.thesurvey.api.service.PointHistoryService;
+
+import org.springframework.stereotype.Component;
+
+import static com.thesurvey.api.domain.EnumTypeEntity.PointTransactionType.LONG_ANSWER_CONSUME;
+import static com.thesurvey.api.domain.EnumTypeEntity.PointTransactionType.LONG_ANSWER_REWARD;
+import static com.thesurvey.api.domain.EnumTypeEntity.PointTransactionType.MULTIPLE_CHOICES_CONSUME;
+import static com.thesurvey.api.domain.EnumTypeEntity.PointTransactionType.MULTIPLE_CHOICES_REWARD;
+import static com.thesurvey.api.domain.EnumTypeEntity.PointTransactionType.SHORT_ANSWER_CONSUME;
+import static com.thesurvey.api.domain.EnumTypeEntity.PointTransactionType.SHORT_ANSWER_REWARD;
+import static com.thesurvey.api.domain.EnumTypeEntity.PointTransactionType.SINGLE_CHOICE_CONSUME;
+import static com.thesurvey.api.domain.EnumTypeEntity.PointTransactionType.SINGLE_CHOICE_REWARD;
+
+@Component
+public class PointUtil {
+
+    private final QuestionBankRepository questionBankRepository;
+
+    private final PointHistoryService pointHistoryService;
+
+    public PointUtil(QuestionBankRepository questionBankRepository, PointHistoryService pointHistoryService) {
+        this.questionBankRepository = questionBankRepository;
+        this.pointHistoryService = pointHistoryService;
+    }
+
+    public int calculateSurveyCreatePoints(UUID surveyId) {
+        List<QuestionBank> questionBankList = questionBankRepository.findAllBySurveyId(surveyId);
+        int createPoints = 0;
+        for (QuestionBank questionBank : questionBankList) {
+            switch (questionBank.getQuestionType()) {
+                case SINGLE_CHOICE:
+                    createPoints += SINGLE_CHOICE_CONSUME.getTransactionPoint();
+                    break;
+
+                case MULTIPLE_CHOICES:
+                    createPoints += MULTIPLE_CHOICES_CONSUME.getTransactionPoint();
+                    break;
+
+                case SHORT_ANSWER:
+                    createPoints += SHORT_ANSWER_CONSUME.getTransactionPoint();
+                    break;
+
+                case LONG_ANSWER:
+                    createPoints += LONG_ANSWER_CONSUME.getTransactionPoint();
+                    break;
+
+                default:
+                    throw new BadRequestExceptionMapper(ErrorMessage.INVALID_QUESTION_TYPE);
+            }
+        }
+        return createPoints;
+    }
+
+    public int calculateSurveyMaxRewardPoints(QuestionType questionType) {
+        switch (questionType) {
+            case SINGLE_CHOICE:
+                return SINGLE_CHOICE_REWARD.getTransactionPoint();
+
+            case MULTIPLE_CHOICES:
+                return MULTIPLE_CHOICES_REWARD.getTransactionPoint();
+
+            case SHORT_ANSWER:
+                return SHORT_ANSWER_REWARD.getTransactionPoint();
+
+            case LONG_ANSWER:
+                return LONG_ANSWER_REWARD.getTransactionPoint();
+
+            default:
+                throw new BadRequestExceptionMapper(ErrorMessage.INVALID_QUESTION_TYPE);
+        }
+    }
+
+    public int getSurveyMaxRewardPoints(UUID surveyId) {
+        List<QuestionBank> questionBankList = questionBankRepository.findAllBySurveyId(surveyId);
+        int maxRewardPoints = questionBankList.stream()
+            .mapToInt(questionBank -> calculateSurveyMaxRewardPoints(questionBank.getQuestionType()))
+            .sum();
+        return maxRewardPoints;
+    }
+
+    public void validateUserPoint(int surveyCreatePoint, Long userId) {
+        int userTotalPoint = pointHistoryService.getUserTotalPoint(userId);
+        if (userTotalPoint - surveyCreatePoint < 0) {
+            throw new BadRequestExceptionMapper(ErrorMessage.SURVEY_CREATE_POINT_NOT_ENOUGH);
+        }
+    }
+
+}

--- a/api/src/main/java/com/thesurvey/api/util/PointUtil.java
+++ b/api/src/main/java/com/thesurvey/api/util/PointUtil.java
@@ -80,6 +80,10 @@ public class PointUtil {
         }
     }
 
+    /**
+     * {@code maxRewardPoints} is the amount of points a user get when they answer all the
+     * questions in the survey.
+     */
     public int getSurveyMaxRewardPoints(UUID surveyId) {
         List<QuestionBank> questionBankList = questionBankRepository.findAllBySurveyId(surveyId);
         int maxRewardPoints = questionBankList.stream()

--- a/api/src/main/java/com/thesurvey/api/util/StringUtil.java
+++ b/api/src/main/java/com/thesurvey/api/util/StringUtil.java
@@ -15,4 +15,15 @@ public class StringUtil {
         }
         return null;
     }
+
+    public static String trimShortLongAnswer(String value, boolean isRequired) {
+        if (value != null) {
+            if (value.isBlank() && isRequired) {
+                throw new BadRequestExceptionMapper(ErrorMessage.NO_ONLY_WHITESPACE);
+            } else {
+                return value.trim();
+            }
+        }
+        return null;
+    }
 }

--- a/api/src/test/java/com/thesurvey/api/controller/AuthenticationControllerTest.java
+++ b/api/src/test/java/com/thesurvey/api/controller/AuthenticationControllerTest.java
@@ -68,7 +68,7 @@ public class AuthenticationControllerTest extends BaseControllerTest {
         assertThat(content.get("name")).isEqualTo(userRegisterRequestDto.getName());
         assertThat(content.get("role")).isEqualTo(String.valueOf(Role.USER));
         assertThat(content.get("email")).isEqualTo(userRegisterRequestDto.getEmail());
-        assertThat(content.get("userPoints")).isEqualTo(PointHistory.USER_INITIAL_POINT);
+        assertThat(content.get("point")).isEqualTo(PointHistory.USER_INITIAL_POINT);
     }
 
     @Test

--- a/api/src/test/java/com/thesurvey/api/controller/AuthenticationControllerTest.java
+++ b/api/src/test/java/com/thesurvey/api/controller/AuthenticationControllerTest.java
@@ -4,6 +4,7 @@ package com.thesurvey.api.controller;
 import java.util.UUID;
 
 import com.thesurvey.api.domain.EnumTypeEntity.Role;
+import com.thesurvey.api.domain.PointHistory;
 import com.thesurvey.api.dto.request.user.UserLoginRequestDto;
 import com.thesurvey.api.dto.request.user.UserRegisterRequestDto;
 import com.thesurvey.api.repository.UserRepository;
@@ -67,6 +68,7 @@ public class AuthenticationControllerTest extends BaseControllerTest {
         assertThat(content.get("name")).isEqualTo(userRegisterRequestDto.getName());
         assertThat(content.get("role")).isEqualTo(String.valueOf(Role.USER));
         assertThat(content.get("email")).isEqualTo(userRegisterRequestDto.getEmail());
+        assertThat(content.get("userPoints")).isEqualTo(PointHistory.USER_INITIAL_POINT);
     }
 
     @Test

--- a/api/src/test/java/com/thesurvey/api/controller/UserControllerTest.java
+++ b/api/src/test/java/com/thesurvey/api/controller/UserControllerTest.java
@@ -221,6 +221,8 @@ public class UserControllerTest extends BaseControllerTest {
         JSONObject questionOption = questionOptions.getJSONObject(0);
         AnsweredQuestionDto answeredQuestionDto = AnsweredQuestionDto.builder()
             .questionBankId(questionBank.getLong("questionBankId"))
+            .questionType(QuestionType.SINGLE_CHOICE)
+            .isRequired(true)
             .singleChoice(questionOption.getLong("questionOptionId"))
             .build();
 
@@ -253,7 +255,7 @@ public class UserControllerTest extends BaseControllerTest {
                 .with(authentication(submitUserAuthentication))
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(objectMapper.writeValueAsString(answeredQuestionRequestDto)))
-            .andExpect(status().isNoContent());
+            .andExpect(status().isOk());
 
         mockMvc.perform(get("/auth/logout"))
             .andExpect(status().isOk());

--- a/api/src/test/java/com/thesurvey/api/dto/answeredQuestion/AnsweredQuestionDtoValidTest.java
+++ b/api/src/test/java/com/thesurvey/api/dto/answeredQuestion/AnsweredQuestionDtoValidTest.java
@@ -6,6 +6,7 @@ import javax.validation.ConstraintViolation;
 import javax.validation.Validator;
 
 import com.thesurvey.api.controller.SurveyController;
+import com.thesurvey.api.domain.EnumTypeEntity.QuestionType;
 import com.thesurvey.api.dto.request.answeredQuestion.AnsweredQuestionDto;
 import org.junit.jupiter.api.Test;
 
@@ -27,8 +28,10 @@ public class AnsweredQuestionDtoValidTest {
     public void testCorrectInput() {
         // given
         AnsweredQuestionDto answeredQuestionDto = AnsweredQuestionDto.builder()
+            .questionBankId(1L)
+            .questionType(QuestionType.SHORT_ANSWER)
+            .isRequired(true)
             .shortAnswer("This is test short answer.")
-            .longAnswer("This is test long answer")
             .build();
 
         // when
@@ -50,6 +53,9 @@ public class AnsweredQuestionDtoValidTest {
         String maxLengthString = maxLengthStringBuilder.toString();
 
         AnsweredQuestionDto answeredQuestionDto = AnsweredQuestionDto.builder()
+            .questionBankId(1L)
+            .isRequired(true)
+            .questionType(QuestionType.SHORT_ANSWER)
             .shortAnswer(maxLengthString) // violated by @Size
             .longAnswer(maxLengthString) // violated by @Size
             .build();

--- a/api/src/test/java/com/thesurvey/api/dto/answeredQuestion/AnsweredQuestionRequestDtoValidTest.java
+++ b/api/src/test/java/com/thesurvey/api/dto/answeredQuestion/AnsweredQuestionRequestDtoValidTest.java
@@ -9,6 +9,7 @@ import javax.validation.ConstraintViolation;
 import javax.validation.Validator;
 
 import com.thesurvey.api.controller.SurveyController;
+import com.thesurvey.api.domain.EnumTypeEntity.QuestionType;
 import com.thesurvey.api.dto.request.answeredQuestion.AnsweredQuestionDto;
 import com.thesurvey.api.dto.request.answeredQuestion.AnsweredQuestionRequestDto;
 import org.junit.jupiter.api.Test;
@@ -31,8 +32,10 @@ public class AnsweredQuestionRequestDtoValidTest {
     public void testCorrectInput() {
         // given
         AnsweredQuestionDto answeredQuestionDto = AnsweredQuestionDto.builder()
-            .shortAnswer("This tis test short answer.")
-            .longAnswer("This is test long answer")
+            .questionBankId(1L)
+            .questionType(QuestionType.SHORT_ANSWER)
+            .isRequired(true)
+            .shortAnswer("This is test short answer.")
             .build();
 
         List<AnsweredQuestionDto> answers = Arrays.asList(answeredQuestionDto);

--- a/api/src/test/java/com/thesurvey/api/service/AnsweredQuestionServiceTest.java
+++ b/api/src/test/java/com/thesurvey/api/service/AnsweredQuestionServiceTest.java
@@ -1,0 +1,233 @@
+package com.thesurvey.api.service;
+
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
+import java.util.ArrayList;
+import java.util.List;
+
+import com.thesurvey.api.domain.EnumTypeEntity.CertificationType;
+import com.thesurvey.api.domain.EnumTypeEntity.QuestionType;
+import com.thesurvey.api.dto.request.answeredQuestion.AnsweredQuestionDto;
+import com.thesurvey.api.dto.request.answeredQuestion.AnsweredQuestionRequestDto;
+import com.thesurvey.api.dto.request.question.QuestionRequestDto;
+import com.thesurvey.api.dto.request.survey.SurveyRequestDto;
+import com.thesurvey.api.dto.request.user.UserRegisterRequestDto;
+import com.thesurvey.api.dto.response.question.QuestionBankResponseDto;
+import com.thesurvey.api.dto.response.survey.SurveyResponseDto;
+import com.thesurvey.api.dto.response.user.UserResponseDto;
+import com.thesurvey.api.exception.mapper.BadRequestExceptionMapper;
+import com.thesurvey.api.exception.mapper.UnauthorizedRequestExceptionMapper;
+import com.thesurvey.api.repository.UserRepository;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.TestInstance.Lifecycle;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+@SpringBootTest
+@TestInstance(value = Lifecycle.PER_CLASS)
+public class AnsweredQuestionServiceTest {
+
+    @Autowired
+    AuthenticationService authenticationService;
+
+    @Autowired
+    UserRepository userRepository;
+
+    @Autowired
+    SurveyService surveyService;
+
+    @Autowired
+    AnsweredQuestionService answeredQuestionService;
+
+    UserRegisterRequestDto userRegisterRequestDto;
+
+    UserResponseDto testUserResponseDto;
+
+    Authentication testAuthentication;
+
+    UserRegisterRequestDto submitUserRegisterRequestDto;
+
+    UserResponseDto testSubmitUserResponseDto;
+
+    Authentication submitUserAuthentication;
+
+    DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss");
+
+    @BeforeAll
+    void setupBeforeAll() {
+        userRegisterRequestDto = UserRegisterRequestDto.builder()
+            .name("answerQuestionTest")
+            .email("answerQuestionTest@gmail.com")
+            .password("Password40@")
+            .phoneNumber("01012345678")
+            .build();
+        testUserResponseDto = authenticationService.register(userRegisterRequestDto);
+
+        testAuthentication = authenticationService.authenticate(
+            new UsernamePasswordAuthenticationToken(userRegisterRequestDto.getEmail(),
+                userRegisterRequestDto.getPassword()));
+
+        submitUserRegisterRequestDto = UserRegisterRequestDto.builder()
+            .name("answerQuestionTest2")
+            .email("answerQuestionTest2@gmail.com")
+            .password("Password40@")
+            .phoneNumber("01012345678")
+            .build();
+
+        testSubmitUserResponseDto =
+            authenticationService.register(submitUserRegisterRequestDto);
+
+        submitUserAuthentication = authenticationService.authenticate(
+            new UsernamePasswordAuthenticationToken(submitUserRegisterRequestDto.getEmail(),
+                submitUserRegisterRequestDto.getPassword()));
+    }
+
+    @Test
+    void testValidateUserCompletedCertifications() {
+        List<QuestionRequestDto> testQuestionList = new ArrayList<>();
+        testQuestionList.add(
+            QuestionRequestDto.builder()
+                .title("This is test question title")
+                .description("This is test question description")
+                .questionNo(1)
+                .questionType(QuestionType.LONG_ANSWER)
+                .isRequired(true)
+                .build()
+        );
+
+        SurveyRequestDto testSurveyRequestDto = SurveyRequestDto.builder()
+            .title("This is test survey title")
+            .description("This is test survey description")
+            .startedDate(LocalDateTime.parse(LocalDateTime.now(ZoneId.of("Asia/Seoul"))
+                .format(formatter)))
+            .endedDate(LocalDateTime.parse(LocalDateTime.now(ZoneId.of("Asia/Seoul"))
+                .plusDays(2).format(formatter)))
+            .certificationTypes(List.of(CertificationType.GOOGLE,
+                CertificationType.DRIVER_LICENSE)) // to be validated
+            .questions(testQuestionList)
+            .build();
+
+        SurveyResponseDto testSurveyResponseDto = surveyService.createSurvey(testAuthentication,
+            testSurveyRequestDto);
+        List<QuestionBankResponseDto> testQuestionResponseList = testSurveyResponseDto.getQuestions();
+
+        AnsweredQuestionDto answeredQuestionDto = AnsweredQuestionDto.builder()
+            .questionBankId(testQuestionResponseList.get(0).getQuestionBankId())
+            .longAnswer("test long answer")
+            .isRequired(true)
+            .questionType(QuestionType.LONG_ANSWER)
+            .build();
+
+        AnsweredQuestionRequestDto answeredQuestionRequestDto = AnsweredQuestionRequestDto.builder()
+            .surveyId(testSurveyResponseDto.getSurveyId())
+            .answers(List.of(answeredQuestionDto))
+            .build();
+
+        assertThrows(UnauthorizedRequestExceptionMapper.class,
+            () -> answeredQuestionService.createAnswer(submitUserAuthentication,
+                answeredQuestionRequestDto));
+    }
+
+    @Test
+    void testValidateUserNotAnswerAllNotRequiredQuestion() {
+        List<QuestionRequestDto> testQuestionList = new ArrayList<>();
+        testQuestionList.add(
+            QuestionRequestDto.builder()
+                .title("This is test long answer question title")
+                .description("This is test question description")
+                .questionNo(1)
+                .questionType(QuestionType.LONG_ANSWER)
+                .isRequired(false)
+                .build()
+        );
+        testQuestionList.add(
+            QuestionRequestDto.builder()
+                .title("This is test short answer question title")
+                .description("This is test question description")
+                .questionNo(2)
+                .questionType(QuestionType.SHORT_ANSWER)
+                .isRequired(false)
+                .build()
+        );
+        testQuestionList.add(
+            QuestionRequestDto.builder()
+                .title("This is test single choice question title")
+                .description("This is test question description")
+                .questionNo(3)
+                .questionType(QuestionType.SINGLE_CHOICE)
+                .isRequired(false)
+                .build()
+        );
+        testQuestionList.add(
+            QuestionRequestDto.builder()
+                .title("This is test multiple choices question title")
+                .description("This is test question description")
+                .questionNo(4)
+                .questionType(QuestionType.MULTIPLE_CHOICES)
+                .isRequired(false)
+                .build()
+        );
+
+        SurveyRequestDto testSurveyRequestDto = SurveyRequestDto.builder()
+            .title("This is test survey title")
+            .description("This is test survey description")
+            .startedDate(LocalDateTime.parse(LocalDateTime.now(ZoneId.of("Asia/Seoul"))
+                .format(formatter)))
+            .endedDate(LocalDateTime.parse(LocalDateTime.now(ZoneId.of("Asia/Seoul"))
+                .plusDays(2).format(formatter)))
+            .certificationTypes(List.of(CertificationType.NONE))
+            .questions(testQuestionList)
+            .build();
+
+        SurveyResponseDto testSurveyResponseDto = surveyService.createSurvey(testAuthentication,
+            testSurveyRequestDto);
+        List<QuestionBankResponseDto> testQuestionResponseList = testSurveyResponseDto.getQuestions();
+
+        AnsweredQuestionDto longAnsweredQuestionDto = AnsweredQuestionDto.builder()
+            .questionBankId(testQuestionResponseList.get(0).getQuestionBankId())
+            .longAnswer("") // to be validated
+            .isRequired(false)
+            .questionType(QuestionType.LONG_ANSWER)
+            .build();
+
+        AnsweredQuestionDto shortAnsweredQuestionDto = AnsweredQuestionDto.builder()
+            .questionBankId(testQuestionResponseList.get(1).getQuestionBankId())
+            .shortAnswer(null) // to be validated
+            .isRequired(false)
+            .questionType(QuestionType.SHORT_ANSWER)
+            .build();
+
+        AnsweredQuestionDto singleChoiceAnsweredQuestion = AnsweredQuestionDto.builder()
+            .questionBankId(testQuestionResponseList.get(2).getQuestionBankId())
+            .singleChoice(null)// to be validated
+            .isRequired(false)
+            .questionType(QuestionType.SINGLE_CHOICE)
+            .build();
+
+        AnsweredQuestionDto multipleChoicesAnsweredQuestion = AnsweredQuestionDto.builder()
+            .questionBankId(testQuestionResponseList.get(3).getQuestionBankId())
+            .multipleChoices(List.of()) // to be validated
+            .isRequired(false)
+            .questionType(QuestionType.MULTIPLE_CHOICES)
+            .build();
+
+        AnsweredQuestionRequestDto answeredQuestionRequestDto = AnsweredQuestionRequestDto.builder()
+            .surveyId(testSurveyResponseDto.getSurveyId())
+            .answers(List.of(longAnsweredQuestionDto, shortAnsweredQuestionDto,
+                singleChoiceAnsweredQuestion, multipleChoicesAnsweredQuestion))
+            .build();
+
+        assertThrows(BadRequestExceptionMapper.class,
+            () -> answeredQuestionService.createAnswer(submitUserAuthentication,
+                answeredQuestionRequestDto));
+    }
+
+}

--- a/api/src/test/java/com/thesurvey/api/service/AuthenticationServiceTest.java
+++ b/api/src/test/java/com/thesurvey/api/service/AuthenticationServiceTest.java
@@ -36,8 +36,8 @@ public class AuthenticationServiceTest {
     void testRegisterService() {
         // given
         UserRegisterRequestDto userRegisterRequestDto = UserRegisterRequestDto.builder()
-            .name("test")
-            .email("test@gmail.com")
+            .name("authTest")
+            .email("authTest@gmail.com")
             .password("Password40@")
             .phoneNumber("01012345678")
             .build();
@@ -63,14 +63,14 @@ public class AuthenticationServiceTest {
     void testLoginService() {
         // given
         UserRegisterRequestDto userRegisterRequestDto = UserRegisterRequestDto.builder()
-            .name("test")
-            .email("test@gmail.com")
+            .name("loginTest")
+            .email("loginTest@gmail.com")
             .password("Password40@")
             .phoneNumber("01012345678")
             .build();
 
         UserLoginRequestDto userLoginRequestDto = UserLoginRequestDto.builder()
-            .email("test@gmail.com")
+            .email("loginTest@gmail.com")
             .password("Password40@")
             .build();
 

--- a/api/src/test/java/com/thesurvey/api/service/PointHistoryServiceTest.java
+++ b/api/src/test/java/com/thesurvey/api/service/PointHistoryServiceTest.java
@@ -7,10 +7,17 @@ import java.util.ArrayList;
 import java.util.List;
 
 import com.thesurvey.api.domain.EnumTypeEntity.CertificationType;
+import com.thesurvey.api.domain.EnumTypeEntity.PointTransactionType;
 import com.thesurvey.api.domain.EnumTypeEntity.QuestionType;
+import com.thesurvey.api.domain.PointHistory;
+import com.thesurvey.api.dto.request.answeredQuestion.AnsweredQuestionDto;
+import com.thesurvey.api.dto.request.answeredQuestion.AnsweredQuestionRequestDto;
+import com.thesurvey.api.dto.request.question.QuestionOptionRequestDto;
 import com.thesurvey.api.dto.request.question.QuestionRequestDto;
 import com.thesurvey.api.dto.request.survey.SurveyRequestDto;
 import com.thesurvey.api.dto.request.user.UserRegisterRequestDto;
+import com.thesurvey.api.dto.response.question.QuestionBankResponseDto;
+import com.thesurvey.api.dto.response.survey.SurveyResponseDto;
 import com.thesurvey.api.dto.response.user.UserResponseDto;
 import com.thesurvey.api.exception.mapper.BadRequestExceptionMapper;
 import com.thesurvey.api.repository.PointHistoryRepository;
@@ -26,6 +33,7 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 @SpringBootTest
@@ -48,6 +56,9 @@ public class PointHistoryServiceTest {
     SurveyService surveyService;
 
     @Autowired
+    AnsweredQuestionService answeredQuestionService;
+
+    @Autowired
     PointUtil pointUtil;
 
     UserResponseDto testUserResponseDto;
@@ -59,8 +70,8 @@ public class PointHistoryServiceTest {
     @BeforeAll
     void setupBeforeAll() {
         userRegisterRequestDto = UserRegisterRequestDto.builder()
-            .name("test")
-            .email("test@gmail.com")
+            .name("pointHistoryTest")
+            .email("pointHistoryTest@gmail.com")
             .password("Password40@")
             .phoneNumber("01012345678")
             .build();
@@ -71,12 +82,13 @@ public class PointHistoryServiceTest {
     void testValidateUserPoint() {
         List<QuestionRequestDto> testQuestionList = new ArrayList<>();
         // To increase the required points for creating a survey, 100 survey questions are generated
+        int questionNo = 1;
         for (int i = 0; i < 100; i++) {
             testQuestionList.add(
                 QuestionRequestDto.builder()
                     .title("This is test question title")
                     .description("This is test question description")
-                    .questionNo(1)
+                    .questionNo(questionNo++)
                     .questionType(QuestionType.LONG_ANSWER)
                     .isRequired(true)
                     .build()
@@ -101,6 +113,160 @@ public class PointHistoryServiceTest {
         assertThrows(BadRequestExceptionMapper.class,
             () -> surveyService.createSurvey(authentication,
                 surveyRequestDto));
+    }
+
+    @Test
+    void testUserTotalPointAfterCreateAnswer() {
+        // given
+        UserRegisterRequestDto userRegisterRequestDto = UserRegisterRequestDto.builder()
+            .name("pointHistoryTest2")
+            .email("pointHistoryTest2@gmail.com")
+            .password("Password40@")
+            .phoneNumber("01012345678")
+            .build();
+        UserResponseDto testUserResponseDto =
+            authenticationService.register(userRegisterRequestDto);
+
+        List<QuestionRequestDto> testQuestionList = new ArrayList<>();
+        testQuestionList.add(
+            QuestionRequestDto.builder()
+                .title("This is test long answer question title")
+                .description("This is test long answer question description")
+                .questionNo(1)
+                .questionType(QuestionType.LONG_ANSWER)
+                .isRequired(true)
+                .build()
+        );
+
+        testQuestionList.add(
+            QuestionRequestDto.builder()
+                .title("This is test short answer question title")
+                .description("This is test short answer question description")
+                .questionNo(2)
+                .questionType(QuestionType.SHORT_ANSWER)
+                .isRequired(true)
+                .build()
+        );
+
+        testQuestionList.add(
+            QuestionRequestDto.builder()
+                .title("This is test single choice question title")
+                .description("This is test single choice question description")
+                .questionNo(3)
+                .questionType(QuestionType.SINGLE_CHOICE)
+                .questionOptions(List.of(
+                    QuestionOptionRequestDto.builder()
+                        .option("test option title")
+                        .description("test option description")
+                        .build()
+                ))
+                .isRequired(true)
+                .build()
+        );
+
+        SurveyRequestDto surveyRequestDto = SurveyRequestDto.builder()
+            .title("This is test survey title")
+            .description("This is test survey description")
+            .startedDate(LocalDateTime.parse(LocalDateTime.now(ZoneId.of("Asia/Seoul"))
+                .format(formatter)))
+            .endedDate(LocalDateTime.parse(LocalDateTime.now(ZoneId.of("Asia/Seoul"))
+                .plusDays(2).format(formatter)))
+            .certificationTypes(List.of(CertificationType.GOOGLE))
+            .questions(testQuestionList)
+            .build();
+
+        Authentication authentication = authenticationService.authenticate(
+            new UsernamePasswordAuthenticationToken(userRegisterRequestDto.getEmail(),
+                userRegisterRequestDto.getPassword())
+        );
+
+        // when
+        surveyService.createSurvey(authentication, surveyRequestDto);
+
+        // then
+        assertEquals(pointHistoryService.getUserTotalPoint(testUserResponseDto.getUserId()),
+            PointHistory.USER_INITIAL_POINT -
+                (PointTransactionType.LONG_ANSWER_CONSUME.getTransactionPoint()
+                    + PointTransactionType.SHORT_ANSWER_CONSUME.getTransactionPoint()
+                    + PointTransactionType.SINGLE_CHOICE_CONSUME.getTransactionPoint()));
+    }
+
+    @Test
+    void testUserTotalPointAfterSubmitAnswer() {
+        // given
+        UserRegisterRequestDto userRegisterRequestDto = UserRegisterRequestDto.builder()
+            .name("pointHistoryTest3")
+            .email("pointHistoryTest3@gmail.com")
+            .password("Password40@")
+            .phoneNumber("01012345678")
+            .build();
+        authenticationService.register(userRegisterRequestDto);
+
+        List<QuestionRequestDto> testQuestionList = new ArrayList<>();
+        testQuestionList.add(
+            QuestionRequestDto.builder()
+                .title("This is test question title")
+                .description("This is test question description")
+                .questionNo(1)
+                .questionType(QuestionType.LONG_ANSWER)
+                .isRequired(true)
+                .build()
+        );
+
+        SurveyRequestDto surveyRequestDto = SurveyRequestDto.builder()
+            .title("This is test survey title")
+            .description("This is test survey description")
+            .startedDate(LocalDateTime.parse(LocalDateTime.now(ZoneId.of("Asia/Seoul"))
+                .format(formatter)))
+            .endedDate(LocalDateTime.parse(LocalDateTime.now(ZoneId.of("Asia/Seoul"))
+                .plusDays(2).format(formatter)))
+            .certificationTypes(List.of(CertificationType.NONE))
+            .questions(testQuestionList)
+            .build();
+
+        Authentication authentication = authenticationService.authenticate(
+            new UsernamePasswordAuthenticationToken(userRegisterRequestDto.getEmail(),
+                userRegisterRequestDto.getPassword())
+        );
+
+        SurveyResponseDto testSurveyResponseDto = surveyService.createSurvey(authentication,
+            surveyRequestDto);
+
+        List<QuestionBankResponseDto> testQuestionResponseList =
+            testSurveyResponseDto.getQuestions();
+
+        UserRegisterRequestDto submitUserRequestDto = UserRegisterRequestDto.builder()
+            .name("pointHistoryTest4")
+            .email("pointHistoryTest4@gmail.com")
+            .password("Password40@")
+            .phoneNumber("01012345678")
+            .build();
+
+        UserResponseDto submitUserResponseDto =
+            authenticationService.register(submitUserRequestDto);
+
+        Authentication submitUserAuthentication = authenticationService.authenticate(
+            new UsernamePasswordAuthenticationToken(submitUserRequestDto.getEmail(),
+                submitUserRequestDto.getPassword()));
+
+        AnsweredQuestionDto answeredQuestionDto = AnsweredQuestionDto.builder()
+            .questionBankId(testQuestionResponseList.get(0).getQuestionBankId())
+            .longAnswer("test long answer")
+            .isRequired(true)
+            .questionType(QuestionType.LONG_ANSWER)
+            .build();
+
+        AnsweredQuestionRequestDto answeredQuestionRequestDto = AnsweredQuestionRequestDto.builder()
+            .surveyId(testSurveyResponseDto.getSurveyId())
+            .answers(List.of(answeredQuestionDto))
+            .build();
+
+        // when
+        answeredQuestionService.createAnswer(submitUserAuthentication, answeredQuestionRequestDto);
+
+        // then
+        assertEquals(pointHistoryService.getUserTotalPoint(submitUserResponseDto.getUserId()),
+            PointHistory.USER_INITIAL_POINT + PointTransactionType.LONG_ANSWER_REWARD.getTransactionPoint());
     }
 
 }

--- a/api/src/test/java/com/thesurvey/api/service/PointHistoryServiceTest.java
+++ b/api/src/test/java/com/thesurvey/api/service/PointHistoryServiceTest.java
@@ -25,7 +25,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
-import org.springframework.security.test.context.support.WithMockUser;
 
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
@@ -69,7 +68,6 @@ public class PointHistoryServiceTest {
     }
 
     @Test
-    @WithMockUser
     void testValidateUserPoint() {
         List<QuestionRequestDto> testQuestionList = new ArrayList<>();
         // To increase the required points for creating a survey, 100 survey questions are generated

--- a/api/src/test/java/com/thesurvey/api/service/PointHistoryServiceTest.java
+++ b/api/src/test/java/com/thesurvey/api/service/PointHistoryServiceTest.java
@@ -1,0 +1,108 @@
+package com.thesurvey.api.service;
+
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
+import java.util.ArrayList;
+import java.util.List;
+
+import com.thesurvey.api.domain.EnumTypeEntity.CertificationType;
+import com.thesurvey.api.domain.EnumTypeEntity.QuestionType;
+import com.thesurvey.api.dto.request.question.QuestionRequestDto;
+import com.thesurvey.api.dto.request.survey.SurveyRequestDto;
+import com.thesurvey.api.dto.request.user.UserRegisterRequestDto;
+import com.thesurvey.api.dto.response.user.UserResponseDto;
+import com.thesurvey.api.exception.mapper.BadRequestExceptionMapper;
+import com.thesurvey.api.repository.PointHistoryRepository;
+import com.thesurvey.api.repository.UserRepository;
+import com.thesurvey.api.util.PointUtil;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.TestInstance.Lifecycle;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.test.context.support.WithMockUser;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+@SpringBootTest
+@TestInstance(Lifecycle.PER_CLASS)
+public class PointHistoryServiceTest {
+
+    @Autowired
+    PointHistoryRepository pointHistoryRepository;
+
+    @Autowired
+    PointHistoryService pointHistoryService;
+
+    @Autowired
+    AuthenticationService authenticationService;
+
+    @Autowired
+    UserRepository userRepository;
+
+    @Autowired
+    SurveyService surveyService;
+
+    @Autowired
+    PointUtil pointUtil;
+
+    UserResponseDto testUserResponseDto;
+
+    UserRegisterRequestDto userRegisterRequestDto;
+
+    DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss");
+
+    @BeforeAll
+    void setupBeforeAll() {
+        userRegisterRequestDto = UserRegisterRequestDto.builder()
+            .name("test")
+            .email("test@gmail.com")
+            .password("Password40@")
+            .phoneNumber("01012345678")
+            .build();
+        testUserResponseDto = authenticationService.register(userRegisterRequestDto);
+    }
+
+    @Test
+    @WithMockUser
+    void testValidateUserPoint() {
+        List<QuestionRequestDto> testQuestionList = new ArrayList<>();
+        // To increase the required points for creating a survey, 100 survey questions are generated
+        for (int i = 0; i < 100; i++) {
+            testQuestionList.add(
+                QuestionRequestDto.builder()
+                    .title("This is test question title")
+                    .description("This is test question description")
+                    .questionNo(1)
+                    .questionType(QuestionType.LONG_ANSWER)
+                    .isRequired(true)
+                    .build()
+            );
+        }
+
+        SurveyRequestDto surveyRequestDto = SurveyRequestDto.builder()
+            .title("This is test survey title")
+            .description("This is test survey description")
+            .startedDate(LocalDateTime.parse(LocalDateTime.now(ZoneId.of("Asia/Seoul"))
+                .format(formatter)))
+            .endedDate(LocalDateTime.parse(LocalDateTime.now(ZoneId.of("Asia/Seoul"))
+                .plusDays(2).format(formatter)))
+            .certificationTypes(List.of(CertificationType.GOOGLE))
+            .questions(testQuestionList)
+            .build();
+
+        Authentication authentication = authenticationService.authenticate(
+            new UsernamePasswordAuthenticationToken(userRegisterRequestDto.getEmail(),
+                userRegisterRequestDto.getPassword())
+        );
+        assertThrows(BadRequestExceptionMapper.class,
+            () -> surveyService.createSurvey(authentication,
+                surveyRequestDto));
+    }
+
+}


### PR DESCRIPTION
이 PR은 #175 이슈를 수행하였습니다.

**수행한 기능 구현**
- [X]  사용자가 보유한 포인트 조회
- [X]  질문 유형 별 필요한 포인트 차등 적용
- [X]  설문조사 생성 시 포인트 차감
- [X]  설문조사 생성 시 사용자가 필요한 포인트를 보유하고 있는지 검사
- [X]  설문조사 응답 제출 시 보상 포인트 획득
- [ ]  포인트를 사용하여 기프티콘 교환


**추가 사항**
- 사용자 회원가입 시 지급 포인트는 50 포인트 입니다.
- 설문조사 정보 조회 시 획득할 수 있는 포인트 정보를 포함합니다.
- 사용자 정보 조회 시 보유한 포인트 정보를 포함합니다.
- `EnumTypeEntity`에서 질문 유형과 설문조사 생성 및 제출 시 소모, 획득하는 포인트를 포함하는 `PointTransactionType`를 추가하였습니다.
- `isRequired`에 따라서 질문에 응답했는지 안했는지 검사 후 포인트 획득량이 달라지도록 구현하였습니다.

**변경 사항**
- 설문조사 응답 제출 시 보상 포인트를 Response body에 포함하여 응답하도록 수정하였습니다.
- 설문조사 응답 요청 시 JSON 데이터에서  `isRequired`, `QuestionType`을 필요로 합니다.
```
{
  "surveyId": "bfb4ec42-34c2-43b3-9857-4d253ca9bae4",
  "answers": [
      {
          "questionBankId": 1,
          "isRequired" : true, // new
          "questionType" : "SINGLE_CHOICE", // new
          "singleChoice": 2
      }
  ]
}
```


**질문 유형 별 필요한 포인트**
- SINGLE_CHOICE: 2
- MULTIPLE_CHOICES: 4
- SHORT_ANSWER: 4
- LONG_ANSWER: 6

**질문 유형 별 획득 가능한 포인트**
- SINGLE_CHOICE: 1
- MULTIPLE_CHOICES: 2
- SHORT_ANSWER: :2 
- LONG_ANSWER: 3
