### PR TITLE
fix: 서버로 부터 받아오는 에러 메세지 표시, 설문 시작시간 확인 로직 수정, 인증 목록 enum 서버와 같게 수정

### DIFF
--- a/web/src/__tests__/SurveyFormPage.test.tsx
+++ b/web/src/__tests__/SurveyFormPage.test.tsx
@@ -301,7 +301,7 @@ describe('[SurveyFormPage Test]', () => {
 
     // 2) check modal is open
     fireEvent.click(submitButton);
-    const wrongDateModal = await screen.findByText('설문조사 시작일을 확인해 주세요');
+    const wrongDateModal = await screen.findByText('설문조사 시작일은 현재시간 이후여야 합니다');
     expect(wrongDateModal).toBeInTheDocument();
   });
 

--- a/web/src/api/axios.ts
+++ b/web/src/api/axios.ts
@@ -1,12 +1,10 @@
 import axios, { AxiosError, AxiosInstance, AxiosResponse, InternalAxiosRequestConfig } from 'axios';
 
 const instance: AxiosInstance = axios.create({
-  // baseURL: 'https://capstone-mock-api.fly.dev',
-  // baseURL: 'http://localhost:8080/v1',
-
   // FIXME: 원활한 thesurvey.kr 사용을 위한 Base url 변경,
   // FIXME: 구현 및 테스트시 BaseUrl을 변경하여 사용할 것.
   baseURL: 'https://api.thesurvey.kr/v1',
+  // baseURL: 'http://localhost:8080/v1',
   // timeout: 15000,
   withCredentials: true,
 });

--- a/web/src/components/Certification.tsx
+++ b/web/src/components/Certification.tsx
@@ -34,7 +34,7 @@ const Naver = styled(Icons.NAVER).attrs({
   margin-right: 5px;
 `;
 
-const MobilePhone = styled(Icons.MOBILE_PHONE).attrs({
+const IdentityCard = styled(Icons.ID).attrs({
   width: 27,
   height: 27,
 })`
@@ -63,7 +63,6 @@ interface CertificationProps {
 }
 
 export default function Certification({ label, iconOption }: CertificationProps) {
-  // FIXME: CertificationType allow both number and string... it makes happen with switch function
   let tmpLabel: number | string;
   if (typeof label === 'undefined') {
     tmpLabel = -1;
@@ -77,16 +76,16 @@ export default function Certification({ label, iconOption }: CertificationProps)
     switch (tmpLabel) {
       case CertificationType.KAKAO:
         return <Kakao key={label} />;
+      case CertificationType.NAVER:
+        return <Naver key={label} />;
       case CertificationType.GOOGLE:
         return <Google key={label} />;
       case CertificationType.WEBMAIL:
         return <Webmail key={label} />;
-      case CertificationType.NAVER:
-        return <Naver key={label} />;
-      case CertificationType.MOBILE_PHONE:
-        return <MobilePhone key={label} />;
       case CertificationType.DRIVER_LICENSE:
         return <DriverLicense key={label} />;
+      case CertificationType.IDENTITY_CARD:
+        return <IdentityCard key={label} />;
       default:
         return <AuthNone key={label} />;
     }
@@ -94,17 +93,17 @@ export default function Certification({ label, iconOption }: CertificationProps)
   switch (tmpLabel) {
     case CertificationType.KAKAO:
       return <Label key={label}>{AuthLabel.KAKAO}</Label>;
+    case CertificationType.NAVER:
+      return <Label key={label}>{AuthLabel.NAVER}</Label>;
     case CertificationType.GOOGLE:
       return <Label key={label}>{AuthLabel.GOOGLE}</Label>;
     case CertificationType.WEBMAIL:
       return <Label key={label}>{AuthLabel.WEBMAIL}</Label>;
-    case CertificationType.NAVER:
-      return <Label key={label}>{AuthLabel.NAVER}</Label>;
-    case CertificationType.MOBILE_PHONE:
-      return <Label key={label}>{AuthLabel.MOBILE_PHONE}</Label>;
     case CertificationType.DRIVER_LICENSE:
       return <Label key={label}>{AuthLabel.DRIVER_LICENSE}</Label>;
+    case CertificationType.IDENTITY_CARD:
+      return <Label key={label}>{AuthLabel.IDENTITY_CARD}</Label>;
     default:
-      return <Label key={label}>{AuthLabel.NULL}</Label>;
+      return <Label key={label}>{AuthLabel.NONE}</Label>;
   }
 }

--- a/web/src/components/SurveyCreateForm/SurveyCreateForm.tsx
+++ b/web/src/components/SurveyCreateForm/SurveyCreateForm.tsx
@@ -8,6 +8,7 @@ import { QuestionCreateRequest, QuestionType } from '../../types/request/Questio
 import { QuestionOptionCreateRequest } from '../../types/request/QuestionOption';
 import { SurveyCreateRequest } from '../../types/request/Survey';
 import { ValidationErrorMessage, InputCheckResult } from '../../types/userInputCheck';
+import { responseErrorHandle } from '../../utils/responseErrorHandle';
 import { scrollToRef, scrollToTop } from '../../utils/scroll';
 import { validateSurveyData } from '../../utils/validate';
 import RectangleButton from '../Button/RectangleButton';
@@ -60,14 +61,16 @@ export default function SurveyCreateForm({ theme }: SurveyFormProps) {
   const handleSubmit = () => {
     axios
       .post(requests.createSurvey, surveyData)
-      .then(function (response) {
-        console.log(response);
+      .then((response) => {
+        // TODO: 사용한 포인트 표시
+        setConfirmModalOpen(false);
+        setResultModalOpen(true);
       })
-      .catch(function (error) {
-        console.log(error);
+      .catch((error) => {
+        const errorMessages: string[] = responseErrorHandle(error);
+        setWarnText(errorMessages[0]);
+        setAlertModalOpen(true);
       });
-    setConfirmModalOpen(false);
-    setResultModalOpen(true);
   };
 
   useEffect(() => {

--- a/web/src/components/SurveyCreateForm/SurveyCreateForm.tsx
+++ b/web/src/components/SurveyCreateForm/SurveyCreateForm.tsx
@@ -103,7 +103,7 @@ export default function SurveyCreateForm({ theme }: SurveyFormProps) {
         break;
       case ValidationErrorMessage.EARLY_START:
         scrollToTop();
-        setWarnText('설문조사 시작일은 현재시간 이후여야 합니다.');
+        setWarnText('설문조사 시작일은 현재시간 이후여야 합니다');
         setAlertModalOpen(true);
         break;
       case ValidationErrorMessage.EARLY_END:

--- a/web/src/components/SurveyCreateForm/SurveyCreateForm.tsx
+++ b/web/src/components/SurveyCreateForm/SurveyCreateForm.tsx
@@ -100,7 +100,7 @@ export default function SurveyCreateForm({ theme }: SurveyFormProps) {
         break;
       case ValidationErrorMessage.EARLY_START:
         scrollToTop();
-        setWarnText('설문조사 시작일을 확인해 주세요');
+        setWarnText('설문조사 시작일은 현재시간 이후여야 합니다.');
         setAlertModalOpen(true);
         break;
       case ValidationErrorMessage.EARLY_END:

--- a/web/src/components/SurveyCreateForm/SurveyDataForm.tsx
+++ b/web/src/components/SurveyCreateForm/SurveyDataForm.tsx
@@ -157,7 +157,7 @@ export default function SurveyDataForm({
           <CertificationIconList certificationList={surveyData.certificationTypes || []} theme={theme} />
         </SelectedCertificationsContainer>
         <List>
-          {NumberUtils.range(0, 6).map((index: number) => {
+          {NumberUtils.range(1, 7).map((index: number) => {
             return (
               <ListItem key={index}>
                 <CertificationLabel htmlFor={`certification${index}`} theme={theme}>

--- a/web/src/components/SurveyParticipateForm/SurveyParticipateForm.tsx
+++ b/web/src/components/SurveyParticipateForm/SurveyParticipateForm.tsx
@@ -8,9 +8,10 @@ import { AnsweredQuestion, SurveySubmitRequest } from '../../types/request';
 import { QuestionBankResponse } from '../../types/response/QuestionBank';
 import { SurveyResponse } from '../../types/response/Survey';
 import { dateFormatUpToDate, getDDay } from '../../utils/dateFormat';
+import { responseErrorHandle } from '../../utils/responseErrorHandle';
 import { scrollToRef } from '../../utils/scroll';
 import RectangleButton from '../Button/RectangleButton';
-import { SurveyPageResultModal } from '../Modal';
+import { AlertModal, SurveyPageResultModal } from '../Modal';
 import QuestionForm from './QuestionForm';
 
 const Container = styled.div``;
@@ -63,6 +64,8 @@ export default function SurveyParticipateForm({ surveyData, theme }: SurveyParti
   const questionRefs = useRef<HTMLDivElement[]>([]);
   const [endedDate, setEndedDate] = useState<string>('');
   const [resultModalOpen, setResultModalOpen] = useState<boolean>(false);
+  const [alertModalOpen, setAlertModalOpen] = useState<boolean>(false);
+  const [warnText, setWarnText] = useState<string>('');
   const [userAnswers, setUserAnswers] = useState<Array<AnsweredQuestion>>([]);
 
   const remainDate = useMemo(() => getDDay(endedDate), [endedDate]);
@@ -75,14 +78,15 @@ export default function SurveyParticipateForm({ surveyData, theme }: SurveyParti
     };
     axios
       .post(requests.submitSurvey, surveySubmitData)
-      .then(function (response) {
-        console.log(response);
+      .then((response) => {
+        // TODO: 획득 포인트 표시
+        setResultModalOpen(true);
       })
-      .catch(function (error) {
-        console.log(error);
+      .catch((error) => {
+        const errorMessages: string[] = responseErrorHandle(error);
+        setWarnText(errorMessages[0]);
+        setAlertModalOpen(true);
       });
-
-    setResultModalOpen(true);
   };
 
   const turnOnUserAttention = (domIndex: number) => {
@@ -167,6 +171,16 @@ export default function SurveyParticipateForm({ surveyData, theme }: SurveyParti
         </ButtonContainer>
       </BodyContainer>
       {resultModalOpen && <SurveyPageResultModal theme={theme} />}
+      {alertModalOpen && (
+        <AlertModal
+          theme={theme}
+          title="경고"
+          level="WARN"
+          text={warnText}
+          buttonText="확인"
+          onClose={() => setAlertModalOpen(false)}
+        />
+      )}
     </Container>
   );
 }

--- a/web/src/routes/SurveyPages/SurveyListPage.tsx
+++ b/web/src/routes/SurveyPages/SurveyListPage.tsx
@@ -13,6 +13,7 @@ import SurveyListSkeleton from '../../components/Skeleton/SurveyListSkeleton';
 import SurveyListTable from '../../components/SurveyListTable';
 import { useTheme } from '../../hooks/useTheme';
 import { SurveyPageResponse } from '../../types/response/Survey';
+import { responseErrorHandle } from '../../utils/responseErrorHandle';
 
 const Container = styled.div`
   width: 100vw;
@@ -36,29 +37,13 @@ export default function SurveyListPage() {
   });
 
   if (isError) {
-    // TODO: 에러 종류에 따라서 다른 알림 표시
-    // TODO: 에러 처리 로직 분리
-    const { response } = error as AxiosError;
-
-    let labelText = '';
-    let buttonText = '';
-    let navigateRoute = '';
-
-    if (response?.data === '존재하지 않는 페이지입니다.') {
-      labelText = '😥 찾는 페이지가 없습니다...';
-      buttonText = '홈화면으로 돌아가기';
-      navigateRoute = '/';
-    } else {
-      labelText = '😥 로그인이 만료 되었습니다...';
-      buttonText = '로그인 하러 가기';
-      navigateRoute = '/login';
-    }
+    const errorMessages: string[] = responseErrorHandle(error as AxiosError);
 
     return (
       <ErrorPage
-        labelText={labelText}
-        buttonText={buttonText}
-        navigateRoute={navigateRoute}
+        labelText={`😥 ${errorMessages[0]}..`}
+        buttonText={errorMessages[1]}
+        navigateRoute={errorMessages[2]}
         theme={theme}
         toggleTheme={toggleTheme}
       />

--- a/web/src/routes/SurveyPages/SurveyPage.tsx
+++ b/web/src/routes/SurveyPages/SurveyPage.tsx
@@ -12,6 +12,7 @@ import SurveyPageSkeleton from '../../components/Skeleton/SurveyPageSkeleton';
 import SurveyParticipateForm from '../../components/SurveyParticipateForm/SurveyParticipateForm';
 import { useTheme } from '../../hooks/useTheme';
 import { SurveyResponse } from '../../types/response/Survey';
+import { responseErrorHandle } from '../../utils/responseErrorHandle';
 
 const Container = styled.div`
   width: 100vw;
@@ -32,23 +33,13 @@ export default function SurveyPage() {
   });
 
   if (isError) {
-    // TODO: 에러 종류에 따라서 다른 알림 표시
-    // TODO: 에러 처리 로직 분리
-    const { response } = error as AxiosError;
-
-    let labelText = '';
-    let buttonText = '';
-    let navigateRoute = '';
-
-    labelText = '😥 잘못된 설문 입니다...';
-    buttonText = '설문 리스트로 돌아가기';
-    navigateRoute = '/survey';
+    const errorMessages: string[] = responseErrorHandle(error as AxiosError);
 
     return (
       <ErrorPage
-        labelText={labelText}
-        buttonText={buttonText}
-        navigateRoute={navigateRoute}
+        labelText={`😥 ${errorMessages[0]}..`}
+        buttonText={errorMessages[1]}
+        navigateRoute={errorMessages[2]}
         theme={theme}
         toggleTheme={toggleTheme}
       />

--- a/web/src/types/labels.ts
+++ b/web/src/types/labels.ts
@@ -1,12 +1,11 @@
 export enum AuthLabel {
+  NONE = '제한없음',
   KAKAO = '카카오계정',
   NAVER = '네이버계정',
   GOOGLE = '구글계정',
-  ID = '신분증',
-  MOBILE_PHONE = '휴대폰',
-  DRIVER_LICENSE = '운전면허',
   WEBMAIL = '학교웹메일',
-  NULL = '제한없음',
+  DRIVER_LICENSE = '운전면허',
+  IDENTITY_CARD = '신분증',
 }
 
 export type AuthLabelKey = keyof typeof AuthLabel;

--- a/web/src/types/request/Survey.ts
+++ b/web/src/types/request/Survey.ts
@@ -3,12 +3,13 @@ import { QuestionCreateRequest } from './Question';
 import { QuestionBankUpdateRequest } from './QuestionBank';
 
 export enum CertificationType {
+  NONE,
   KAKAO,
   NAVER,
   GOOGLE,
   WEBMAIL,
   DRIVER_LICENSE,
-  MOBILE_PHONE,
+  IDENTITY_CARD,
 }
 
 export interface SurveyCreateRequest {

--- a/web/src/types/response/Survey.ts
+++ b/web/src/types/response/Survey.ts
@@ -30,10 +30,11 @@ export interface SurveyPageResponse extends BaseTime {
 }
 
 enum CertificationType {
+  NONE,
   KAKAO,
   NAVER,
   GOOGLE,
   WEBMAIL,
   DRIVER_LICENSE,
-  MOBILE_PHONE,
+  IDENTITY_CARD,
 }

--- a/web/src/utils/responseErrorHandle.ts
+++ b/web/src/utils/responseErrorHandle.ts
@@ -3,22 +3,24 @@ import { AxiosError } from 'axios';
 export const responseErrorHandle = (error: AxiosError): string[] => {
   const { response } = error as AxiosError;
 
-  let labelText = '';
+  let labelText = `${response?.data}`;
   let buttonText = '';
   let navigateRoute = '';
 
   switch (response?.status) {
     case 400:
-      labelText = `${response?.data}`;
-      buttonText = '확인';
       break;
     case 401:
-      labelText = '로그인이 만료 되었습니다.';
-      buttonText = '로그인 하러 가기';
-      navigateRoute = '/login';
+      if (labelText === '설문조사에 필요한 인증을 하지 않았습니다.') {
+        buttonText = '인증 하러 가기';
+        navigateRoute = '/mypage/auth-list';
+      } else {
+        labelText = '로그인이 만료 되었습니다.';
+        buttonText = '로그인 하러 가기';
+        navigateRoute = '/login';
+      }
       break;
     case 403:
-      labelText = `${response?.data}`;
       buttonText = '설문 리스트로 돌아가기';
       navigateRoute = '/survey';
       break;
@@ -27,7 +29,6 @@ export const responseErrorHandle = (error: AxiosError): string[] => {
       navigateRoute = '/';
       break;
     default:
-      labelText = `${response?.data}`;
       buttonText = '홈화면으로 돌아가기';
       navigateRoute = '/';
       break;

--- a/web/src/utils/responseErrorHandle.ts
+++ b/web/src/utils/responseErrorHandle.ts
@@ -9,26 +9,25 @@ export const responseErrorHandle = (error: AxiosError): string[] => {
 
   switch (response?.status) {
     case 400:
-      labelText = `😥 ${response?.data}..`;
+      labelText = `${response?.data}`;
       buttonText = '확인';
       break;
     case 401:
-      labelText = '😥 로그인이 만료 되었습니다...';
+      labelText = '로그인이 만료 되었습니다.';
       buttonText = '로그인 하러 가기';
       navigateRoute = '/login';
       break;
     case 403:
-      labelText = `😥 ${response?.data}..`;
+      labelText = `${response?.data}`;
       buttonText = '설문 리스트로 돌아가기';
       navigateRoute = '/survey';
       break;
     case 500:
-      labelText = '😥 서버에 문제가 생겼습니다...';
-      buttonText = '홈화면으로 돌아가기';
+      labelText = '서버에 문제가 생겼습니다.';
       navigateRoute = '/';
       break;
     default:
-      labelText = `😥 ${response?.data}..`;
+      labelText = `${response?.data}`;
       buttonText = '홈화면으로 돌아가기';
       navigateRoute = '/';
       break;

--- a/web/src/utils/responseErrorHandle.ts
+++ b/web/src/utils/responseErrorHandle.ts
@@ -1,0 +1,38 @@
+import { AxiosError } from 'axios';
+
+export const responseErrorHandle = (error: AxiosError): string[] => {
+  const { response } = error as AxiosError;
+
+  let labelText = '';
+  let buttonText = '';
+  let navigateRoute = '';
+
+  switch (response?.status) {
+    case 400:
+      labelText = `😥 ${response?.data}..`;
+      buttonText = '확인';
+      break;
+    case 401:
+      labelText = '😥 로그인이 만료 되었습니다...';
+      buttonText = '로그인 하러 가기';
+      navigateRoute = '/login';
+      break;
+    case 403:
+      labelText = `😥 ${response?.data}..`;
+      buttonText = '설문 리스트로 돌아가기';
+      navigateRoute = '/survey';
+      break;
+    case 500:
+      labelText = '😥 서버에 문제가 생겼습니다...';
+      buttonText = '홈화면으로 돌아가기';
+      navigateRoute = '/';
+      break;
+    default:
+      labelText = `😥 ${response?.data}..`;
+      buttonText = '홈화면으로 돌아가기';
+      navigateRoute = '/';
+      break;
+  }
+
+  return [labelText, buttonText, navigateRoute];
+};

--- a/web/src/utils/validate.ts
+++ b/web/src/utils/validate.ts
@@ -68,11 +68,6 @@ export const validatePhoneNumber = (phoneNumber: string): boolean => {
 export const validateStartDate = (startDate: Date, currentDate: Date): boolean => {
   const dateDiff = startDate.getTime() - currentDate.getTime();
 
-  if (Math.abs(dateDiff) < 60000) {
-    if (startDate.getMinutes() >= currentDate.getMinutes()) return true;
-    return false;
-  }
-
   if (dateDiff < 0) return false;
 
   return true;


### PR DESCRIPTION
1. 서버로 부터 받아오는 에러 메세지 표시
> response.data를 설문 생성과 참여 페이지 에서는 AlertModal, 설문 리스트 페이지 에서는 ErrorPage로 표시

2. 설문 시작시간 확인 로직 수정
> 설문조사 시작 시간은 현재 시간 이후여야만 하도록 수정 했습니다.(분 단위)

3. 인증 목록 enum 서버와 같게 수정
> MOBILE_PHONE 삭제
> NONE 추가
> IDENTITY_CARD 추가