### PR TITLE
feat: 특정 설문조사 정보 요청 시 필수 인증을 완료했는지 검사 

### DIFF
--- a/api/src/main/java/com/thesurvey/api/controller/SurveyController.java
+++ b/api/src/main/java/com/thesurvey/api/controller/SurveyController.java
@@ -72,8 +72,9 @@ public class SurveyController {
     })
     @GetMapping("/{surveyId}")
     public ResponseEntity<SurveyResponseDto> getSurvey(
+        @Parameter(hidden = true) Authentication authentication,
         @Parameter(name = "UUID 형식의 surveyId", required = true) @PathVariable UUID surveyId) {
-        return ResponseEntity.ok(surveyService.getSurveyBySurveyIdWithRelatedQuestion(surveyId));
+        return ResponseEntity.ok(surveyService.getSurveyBySurveyIdWithRelatedQuestion(authentication, surveyId));
     }
 
     @Operation(summary = "설문조사 생성", description = "새로운 설문조사를 생성합니다.")

--- a/api/src/main/java/com/thesurvey/api/service/AnsweredQuestionService.java
+++ b/api/src/main/java/com/thesurvey/api/service/AnsweredQuestionService.java
@@ -98,11 +98,6 @@ public class AnsweredQuestionService {
         Survey survey = surveyRepository.findBySurveyId(answeredQuestionRequestDto.getSurveyId())
             .orElseThrow(() -> new NotFoundExceptionMapper(ErrorMessage.SURVEY_NOT_FOUND));
 
-        // validate if a user has already responded to the survey
-        if (answeredQuestionRepository.existsByUserIdAndSurveyId(user.getUserId(),
-            answeredQuestionRequestDto.getSurveyId())) {
-            throw new ForbiddenRequestExceptionMapper(ErrorMessage.ANSWER_ALREADY_SUBMITTED);
-        }
         List<Integer> surveyCertificationList = surveyRepository.findCertificationTypeBySurveyIdAndAuthorId(
             survey.getSurveyId(), survey.getAuthorId());
         validateUserCompletedCertification(surveyCertificationList, user.getUserId());
@@ -201,7 +196,8 @@ public class AnsweredQuestionService {
     }
 
     // validate if the user has completed the necessary certifications for the survey
-    private void validateUserCompletedCertification(List<Integer> surveyCertificationList, Long userId) {
+    public void validateUserCompletedCertification(List<Integer> surveyCertificationList,
+        Long userId) {
         if (surveyCertificationList.contains(CertificationType.NONE.getCertificationTypeId())) {
             return;
         }

--- a/api/src/main/java/com/thesurvey/api/service/SurveyService.java
+++ b/api/src/main/java/com/thesurvey/api/service/SurveyService.java
@@ -98,8 +98,18 @@ public class SurveyService {
     }
 
     @Transactional(readOnly = true)
-    public SurveyResponseDto getSurveyBySurveyIdWithRelatedQuestion(UUID surveyId) {
+    public SurveyResponseDto getSurveyBySurveyIdWithRelatedQuestion(Authentication authentication
+        , UUID surveyId) {
         Survey survey = getSurveyFromSurveyId(surveyId);
+
+        List<Integer> surveyCertificationList =
+            surveyRepository.findCertificationTypeBySurveyIdAndAuthorId(surveyId, survey.getAuthorId());
+        Long userId = UserUtil.getUserIdFromAuthentication(authentication);
+        if(!survey.getAuthorId().equals(userId)){
+            answeredQuestionService.validateUserCompletedCertification(
+                surveyCertificationList, userId);
+        }
+
         return surveyMapper.toSurveyResponseDto(survey, survey.getAuthorId());
     }
 


### PR DESCRIPTION
#179 이슈를 해결합니다.

**추가 사항**
- 특정 설문조사 정보 요청 시 필수 인증을 완료하였는지 검사하는 로직을 추가하였습니다.
- 설문조사 작성자는 자신의 설문조사 정보 요청이 가능합니다.

추가적으로  `validateUserCompletedCertification` 함수에 이미 존재하는 코드를 제거하였습니다.