### PR TITLE
fix: 오동작 방지를 위해 필요에 따라 버튼 비활성화

### DIFF
--- a/web/src/components/Button/RectangleButton.tsx
+++ b/web/src/components/Button/RectangleButton.tsx
@@ -9,6 +9,7 @@ const Button = styled.button<{
   backgroundHover: string;
   fontSize: string;
   fontWeight: string;
+  disabled: boolean;
 }>`
   padding: 2vh 2vw 2vh 2vw;
   width: ${(props) => props.width};
@@ -17,9 +18,9 @@ const Button = styled.button<{
   border: none;
   border-radius: ${(props) => props.theme.borderRadius};
   color: ${(props) => props.textColor};
-  background-color: ${(props) => props.backgroundColor};
+  background-color: ${(props) => (props.disabled ? props.backgroundHover : props.backgroundColor)};
   transition: 200ms background ease;
-  cursor: pointer;
+  cursor: ${(props) => (props.disabled ? 'not-allowed' : 'pointer')};
 
   &:hover {
     background-color: ${(props) => props.backgroundHover};
@@ -34,6 +35,7 @@ interface RectangleButtonProps {
   hoverColor: string;
   fontSize?: string;
   fontWeight?: string;
+  disabled?: boolean;
   handleClick: () => void;
   theme: DefaultTheme;
 }
@@ -46,6 +48,7 @@ export default function RectangleButton({
   hoverColor,
   fontSize,
   fontWeight,
+  disabled,
   handleClick,
   theme,
 }: RectangleButtonProps) {
@@ -58,6 +61,7 @@ export default function RectangleButton({
       backgroundHover={hoverColor}
       fontSize={fontSize || '18px'}
       fontWeight={fontWeight || '600'}
+      disabled={disabled || false}
       onClick={handleClick}
     >
       {text}

--- a/web/src/components/Modal/HeaderModal.tsx
+++ b/web/src/components/Modal/HeaderModal.tsx
@@ -11,7 +11,7 @@ import { RootState } from '../../reducers';
 import { setLoggedIn, setSubPageOpen } from '../../types/header';
 import { UserAuthListResponse } from '../../types/response/User';
 import { initializeAuthList } from '../../utils/authService';
-import { clearUserInformation } from '../../utils/UserUtils';
+import { clearUserInformation, updateUserInformation } from '../../utils/UserUtils';
 
 const SubPageContainer = styled.div`
   display: flex;
@@ -67,19 +67,8 @@ export default function Header({ theme }: HeaderProps) {
   };
 
   const navigateMypage = async () => {
+    updateUserInformation(dispatch, navigate);
     dispatch(setSubPageOpen(!isSubPageOpen));
-    axios
-      .get<UserAuthListResponse>(requests.getUserAuthList)
-      .then((getAuthListResponse) => {
-        if (getAuthListResponse.status === 200) {
-          console.log('getUserData Success!');
-          initializeAuthList(getAuthListResponse.data, dispatch);
-          navigate('../../../mypage');
-        }
-      })
-      .catch((error) => {
-        console.log(error);
-      });
   };
 
   const subPageRef = useRef<HTMLDivElement>(null);

--- a/web/src/components/Modal/SurveyPreviewModal.tsx
+++ b/web/src/components/Modal/SurveyPreviewModal.tsx
@@ -119,6 +119,7 @@ interface ModalProps {
 }
 
 export default function SurveyPreviewModal({ surveyItem, setPreviewModalOpen, theme }: ModalProps) {
+  const date = new Date();
   const remainDate = useMemo(() => getDDay(surveyItem.endedDate), [surveyItem.endedDate]);
   const navigate = useNavigate();
   const modalRef = useRef<HTMLDivElement>(null);
@@ -132,7 +133,7 @@ export default function SurveyPreviewModal({ surveyItem, setPreviewModalOpen, th
   });
 
   useEffect(() => {
-    if (validateStartDate(new Date(surveyItem.startedDate), new Date())) {
+    if (validateStartDate(new Date(surveyItem.startedDate), date)) {
       setDisableButton(true);
     }
   }, [surveyItem.startedDate]);
@@ -172,7 +173,11 @@ export default function SurveyPreviewModal({ surveyItem, setPreviewModalOpen, th
             textColor="white"
             backgroundColor={theme.colors.primary}
             hoverColor={theme.colors.prhover}
-            text={disableButton ? `${dateFormatUpToMinute(String(surveyItem.startedDate))} 시작` : '설문 조사 시작하기'}
+            text={
+              disableButton
+                ? `${dateFormatUpToMinute(String(surveyItem.startedDate))} 부터 참여가능`
+                : '설문 조사 참여하기'
+            }
             theme={theme}
             handleClick={() => navigate(`/survey/${surveyItem.surveyId}`)}
             width="50%"

--- a/web/src/components/Modal/SurveyPreviewModal.tsx
+++ b/web/src/components/Modal/SurveyPreviewModal.tsx
@@ -1,9 +1,12 @@
 import React, { useEffect, useMemo, useRef, useState } from 'react';
 
+import { useSelector } from 'react-redux';
 import { useNavigate } from 'react-router-dom';
 import styled, { DefaultTheme } from 'styled-components';
 
 import { useOnClickOutside } from '../../hooks/useOnClickOutside';
+import { RootState } from '../../reducers';
+import { CertificationType } from '../../types/request';
 import { SurveyAbstractResponse } from '../../types/response/Survey';
 import { dateFormatUpToMinute, getDDay } from '../../utils/dateFormat';
 import { validateStartDate } from '../../utils/validate';
@@ -123,7 +126,9 @@ export default function SurveyPreviewModal({ surveyItem, setPreviewModalOpen, th
   const remainDate = useMemo(() => getDDay(surveyItem.endedDate), [surveyItem.endedDate]);
   const navigate = useNavigate();
   const modalRef = useRef<HTMLDivElement>(null);
-  const [disableButton, setDisableButton] = useState<boolean>(false);
+  const [isSurveyStart, setIsSurveyStart] = useState<boolean>(true);
+  const [isAuthor, setIsAuthor] = useState<boolean>(false);
+  const userState = useSelector((state: RootState) => state.userInformation);
 
   useOnClickOutside({
     ref: modalRef,
@@ -133,10 +138,12 @@ export default function SurveyPreviewModal({ surveyItem, setPreviewModalOpen, th
   });
 
   useEffect(() => {
+    // Check survey is start
     if (validateStartDate(new Date(surveyItem.startedDate), date)) {
-      setDisableButton(true);
+      setIsSurveyStart(false);
     }
-  }, [surveyItem.startedDate]);
+    // TODO: 본인이 만든 설문이면 수정 페이지로 이동 시켜주기
+  }, [surveyItem.surveyId]);
 
   return (
     <Container>
@@ -174,14 +181,14 @@ export default function SurveyPreviewModal({ surveyItem, setPreviewModalOpen, th
             backgroundColor={theme.colors.primary}
             hoverColor={theme.colors.prhover}
             text={
-              disableButton
-                ? `${dateFormatUpToMinute(String(surveyItem.startedDate))} 부터 참여가능`
-                : '설문 조사 참여하기'
+              isSurveyStart
+                ? '설문 조사 참여하기'
+                : `${dateFormatUpToMinute(String(surveyItem.startedDate))} 부터 참여가능`
             }
             theme={theme}
             handleClick={() => navigate(`/survey/${surveyItem.surveyId}`)}
             width="50%"
-            disabled={disableButton}
+            disabled={!isSurveyStart}
           />
         </ButtonContainer>
       </ModalContainer>

--- a/web/src/components/Modal/SurveyPreviewModal.tsx
+++ b/web/src/components/Modal/SurveyPreviewModal.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo, useRef } from 'react';
+import React, { useEffect, useMemo, useRef, useState } from 'react';
 
 import { useNavigate } from 'react-router-dom';
 import styled, { DefaultTheme } from 'styled-components';
@@ -6,6 +6,7 @@ import styled, { DefaultTheme } from 'styled-components';
 import { useOnClickOutside } from '../../hooks/useOnClickOutside';
 import { SurveyAbstractResponse } from '../../types/response/Survey';
 import { dateFormatUpToMinute, getDDay } from '../../utils/dateFormat';
+import { validateStartDate } from '../../utils/validate';
 import { DeleteImage } from '../Button/ImageButtons';
 import RectangleButton from '../Button/RectangleButton';
 import CertificationIconList from '../CertificationIconList';
@@ -121,6 +122,7 @@ export default function SurveyPreviewModal({ surveyItem, setPreviewModalOpen, th
   const remainDate = useMemo(() => getDDay(surveyItem.endedDate), [surveyItem.endedDate]);
   const navigate = useNavigate();
   const modalRef = useRef<HTMLDivElement>(null);
+  const [disableButton, setDisableButton] = useState<boolean>(false);
 
   useOnClickOutside({
     ref: modalRef,
@@ -128,6 +130,12 @@ export default function SurveyPreviewModal({ surveyItem, setPreviewModalOpen, th
       setPreviewModalOpen(false);
     },
   });
+
+  useEffect(() => {
+    if (validateStartDate(new Date(surveyItem.startedDate), new Date())) {
+      setDisableButton(true);
+    }
+  }, [surveyItem.startedDate]);
 
   return (
     <Container>
@@ -164,10 +172,11 @@ export default function SurveyPreviewModal({ surveyItem, setPreviewModalOpen, th
             textColor="white"
             backgroundColor={theme.colors.primary}
             hoverColor={theme.colors.prhover}
-            text="설문 조사 시작하기"
+            text={disableButton ? `${dateFormatUpToMinute(String(surveyItem.startedDate))} 시작` : '설문 조사 시작하기'}
             theme={theme}
             handleClick={() => navigate(`/survey/${surveyItem.surveyId}`)}
             width="50%"
+            disabled={disableButton}
           />
         </ButtonContainer>
       </ModalContainer>

--- a/web/src/components/SurveyCreateForm/SurveyCreateForm.tsx
+++ b/web/src/components/SurveyCreateForm/SurveyCreateForm.tsx
@@ -312,7 +312,7 @@ export default function SurveyCreateForm({ theme }: SurveyFormProps) {
           theme={theme}
           handleClick={validation}
           width="30%"
-          disabled={numOfContext >= 1000 || confirmModalOpen}
+          disabled={numOfContext >= 10 || confirmModalOpen || resultModalOpen}
         />
       </ButtonContainer>
 

--- a/web/src/components/SurveyCreateForm/SurveyCreateForm.tsx
+++ b/web/src/components/SurveyCreateForm/SurveyCreateForm.tsx
@@ -85,7 +85,7 @@ export default function SurveyCreateForm({ theme }: SurveyFormProps) {
   }, [recentCreate]);
 
   useEffect(() => {
-    if (numOfContext >= 1000) {
+    if (numOfContext > 1000) {
       setWarnText(`질문 수와 옵션 수의 합이 1000개 이하여야 합니다. 현재 ${numOfContext}개`);
       setAlertModalOpen(true);
     }
@@ -312,7 +312,7 @@ export default function SurveyCreateForm({ theme }: SurveyFormProps) {
           theme={theme}
           handleClick={validation}
           width="30%"
-          disabled={numOfContext >= 10 || confirmModalOpen || resultModalOpen}
+          disabled={numOfContext > 1000 || confirmModalOpen || resultModalOpen}
         />
       </ButtonContainer>
 

--- a/web/src/components/SurveyCreateForm/SurveyCreateForm.tsx
+++ b/web/src/components/SurveyCreateForm/SurveyCreateForm.tsx
@@ -312,7 +312,7 @@ export default function SurveyCreateForm({ theme }: SurveyFormProps) {
           theme={theme}
           handleClick={validation}
           width="30%"
-          disabled={numOfContext >= 1000}
+          disabled={numOfContext >= 1000 || confirmModalOpen}
         />
       </ButtonContainer>
 

--- a/web/src/components/SurveyCreateForm/SurveyCreateForm.tsx
+++ b/web/src/components/SurveyCreateForm/SurveyCreateForm.tsx
@@ -60,6 +60,7 @@ export default function SurveyCreateForm({ theme }: SurveyFormProps) {
     questions: [],
   });
   const [usedPoint, setUsedPoint] = useState<number>(0);
+  const [numOfContext, setNumOfContext] = useState<number>(0);
 
   const handleSubmit = () => {
     axios
@@ -82,6 +83,13 @@ export default function SurveyCreateForm({ theme }: SurveyFormProps) {
       scrollToRef(questionRefs, recentCreate);
     }
   }, [recentCreate]);
+
+  useEffect(() => {
+    if (numOfContext >= 1000) {
+      setWarnText(`질문 수와 옵션 수의 합이 1000개 이하여야 합니다. 현재 ${numOfContext}개`);
+      setAlertModalOpen(true);
+    }
+  }, [numOfContext]);
 
   const setAlertNotificationStyle = (errorIndex: number) => {
     surveyData.questions.forEach((question: QuestionCreateRequest) => {
@@ -145,6 +153,7 @@ export default function SurveyCreateForm({ theme }: SurveyFormProps) {
     newQuestions.splice(questionId + 1, 0, newQuestion);
     setSurveyData({ ...surveyData, questions: newQuestions });
     setRecentCreate(questionId + 1);
+    setNumOfContext(numOfContext + 1);
   };
 
   const deleteQuestionAtId = (questionId: number) => {
@@ -155,6 +164,7 @@ export default function SurveyCreateForm({ theme }: SurveyFormProps) {
     newQuestions.splice(questionId, 1);
     setSurveyData({ ...surveyData, questions: newQuestions });
     setRecentCreate(newQuestions.length === 0 ? undefined : newQuestions.length - 1);
+    setNumOfContext(numOfContext - 1);
   };
 
   const addOptionAtBottom = (questionId: number) => {
@@ -169,6 +179,7 @@ export default function SurveyCreateForm({ theme }: SurveyFormProps) {
     const newQuestions = [...surveyData.questions];
     newQuestions[questionId] = { ...newQuestions[questionId], questionOptions: newOptions };
     setSurveyData({ ...surveyData, questions: newQuestions });
+    setNumOfContext(numOfContext + 1);
   };
 
   const deleteOptionAtId = (questionId: number, optionId: number) => {
@@ -180,6 +191,7 @@ export default function SurveyCreateForm({ theme }: SurveyFormProps) {
     const newQuestions = [...surveyData.questions];
     newQuestions[questionId] = { ...newQuestions[questionId], questionOptions: newOptions };
     setSurveyData({ ...surveyData, questions: newQuestions });
+    setNumOfContext(numOfContext + 1);
   };
 
   const editRequiredCertificationList = (value: number, isChecked: boolean) => {
@@ -300,6 +312,7 @@ export default function SurveyCreateForm({ theme }: SurveyFormProps) {
           theme={theme}
           handleClick={validation}
           width="30%"
+          disabled={numOfContext >= 1000}
         />
       </ButtonContainer>
 

--- a/web/src/components/SurveyParticipateForm/SurveyParticipateForm.tsx
+++ b/web/src/components/SurveyParticipateForm/SurveyParticipateForm.tsx
@@ -177,7 +177,7 @@ export default function SurveyParticipateForm({ surveyData, theme }: SurveyParti
             theme={theme}
             handleClick={handleSubmitButtonClick}
             width="20vw"
-            disabled={confirmModalOpen}
+            disabled={confirmModalOpen || resultModalOpen}
           />
         </ButtonContainer>
       </BodyContainer>

--- a/web/src/components/SurveyParticipateForm/SurveyParticipateForm.tsx
+++ b/web/src/components/SurveyParticipateForm/SurveyParticipateForm.tsx
@@ -177,7 +177,7 @@ export default function SurveyParticipateForm({ surveyData, theme }: SurveyParti
             theme={theme}
             handleClick={handleSubmitButtonClick}
             width="20vw"
-            disabled={resultModalOpen}
+            disabled={confirmModalOpen}
           />
         </ButtonContainer>
       </BodyContainer>

--- a/web/src/components/SurveyParticipateForm/SurveyParticipateForm.tsx
+++ b/web/src/components/SurveyParticipateForm/SurveyParticipateForm.tsx
@@ -13,7 +13,7 @@ import { removeEmptyAnswer } from '../../utils/removeEmptyAnswer';
 import { responseErrorHandle } from '../../utils/responseErrorHandle';
 import { scrollToRef } from '../../utils/scroll';
 import RectangleButton from '../Button/RectangleButton';
-import { AlertModal, SurveyPageResultModal } from '../Modal';
+import { AlertModal, ConfirmModal, SurveyPageResultModal } from '../Modal';
 import QuestionForm from './QuestionForm';
 
 const Container = styled.div``;
@@ -72,6 +72,7 @@ export default function SurveyParticipateForm({ surveyData, theme }: SurveyParti
   const [endedDate, setEndedDate] = useState<string>('');
   const [resultModalOpen, setResultModalOpen] = useState<boolean>(false);
   const [alertModalOpen, setAlertModalOpen] = useState<boolean>(false);
+  const [confirmModalOpen, setConfirmModalOpen] = useState<boolean>(false);
   const [warnText, setWarnText] = useState<string>('');
   const [userAnswers, setUserAnswers] = useState<Array<AnsweredQuestion>>([]);
   const [earnedPoint, setEarnedPoint] = useState<number>(0);
@@ -88,11 +89,13 @@ export default function SurveyParticipateForm({ surveyData, theme }: SurveyParti
       .then((response) => {
         setEarnedPoint(response.data.rewardPoints);
         setResultModalOpen(true);
+        setConfirmModalOpen(false);
       })
       .catch((error) => {
         const errorMessages: string[] = responseErrorHandle(error, dispatch);
         setWarnText(errorMessages[0]);
         setAlertModalOpen(true);
+        setConfirmModalOpen(false);
       });
   };
 
@@ -126,7 +129,7 @@ export default function SurveyParticipateForm({ surveyData, theme }: SurveyParti
     const answersVerificationResult = checkAnswers();
 
     if (answersVerificationResult) {
-      postSurveyAnswers();
+      setConfirmModalOpen(true);
     }
   };
 
@@ -174,10 +177,13 @@ export default function SurveyParticipateForm({ surveyData, theme }: SurveyParti
             theme={theme}
             handleClick={handleSubmitButtonClick}
             width="20vw"
+            disabled={resultModalOpen}
           />
         </ButtonContainer>
       </BodyContainer>
+
       {resultModalOpen && <SurveyPageResultModal point={earnedPoint} theme={theme} />}
+
       {alertModalOpen && (
         <AlertModal
           theme={theme}
@@ -186,6 +192,16 @@ export default function SurveyParticipateForm({ surveyData, theme }: SurveyParti
           text={warnText}
           buttonText="확인"
           onClose={() => setAlertModalOpen(false)}
+        />
+      )}
+      {confirmModalOpen && (
+        <ConfirmModal
+          theme={theme}
+          title="확인"
+          level="INFO"
+          text="제출하시겠습니까?"
+          handleCancelClick={() => setConfirmModalOpen(false)}
+          handleConfirmClick={() => postSurveyAnswers()}
         />
       )}
     </Container>

--- a/web/src/utils/validate.ts
+++ b/web/src/utils/validate.ts
@@ -59,7 +59,7 @@ export const validatePhoneNumber = (phoneNumber: string): boolean => {
 };
 
 /**
- * Validate start date is same or later than current date by minutes
+ * Validate start date is same or later than current date
  *
  * @param {Date} startDate Start date
  * @param {Date} currentDate Current date


### PR DESCRIPTION
1. 설문 시작 전에 설문 참여버튼 비활성화 (필수인증 완료 여부는 백앤드에서 확인)
2. 설문 참여, 제작 페이지에서 제출버튼 비활성화 하여 여러번 요청을 보낼수 있는 상황 방지
3. 설문 제작 페이지에서 질문수와 옵션수의 합이 1000개가 넘으면 제출버튼 비활성화
4. 포인트 사용, 획득시 업데이트 안되는 문제 해결

Closes #181 