### PR TITLE
refactor: 사용자가 생성한 설문조사 리스트 요청 시 JSON 데이터 포맷 변경

### DIFF
--- a/api/src/main/java/com/thesurvey/api/controller/UserController.java
+++ b/api/src/main/java/com/thesurvey/api/controller/UserController.java
@@ -1,10 +1,14 @@
 package com.thesurvey.api.controller;
 
+import java.util.UUID;
+
+import javax.validation.Valid;
+
 import com.thesurvey.api.dto.request.user.UserCertificationUpdateRequestDto;
 import com.thesurvey.api.dto.request.user.UserUpdateRequestDto;
 import com.thesurvey.api.dto.response.user.UserResponseDto;
 import com.thesurvey.api.dto.response.user.UserSurveyResultDto;
-import com.thesurvey.api.dto.response.user.UserSurveyTitleDto;
+import com.thesurvey.api.dto.response.user.UserSurveyTitleListDto;
 import com.thesurvey.api.dto.response.userCertification.UserCertificationListDto;
 import com.thesurvey.api.service.SurveyService;
 import com.thesurvey.api.service.UserCertificationService;
@@ -16,14 +20,17 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
+
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.Authentication;
-import org.springframework.web.bind.annotation.*;
-
-import javax.validation.Valid;
-import java.util.List;
-import java.util.UUID;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
 
 @Tag(name = "사용자", description = "User Controller")
 @RestController
@@ -37,7 +44,7 @@ public class UserController {
     private final SurveyService surveyService;
 
     public UserController(UserService userService,
-                          UserCertificationService userCertificationService, SurveyService surveyService) {
+        UserCertificationService userCertificationService, SurveyService surveyService) {
         this.userService = userService;
         this.userCertificationService = userCertificationService;
         this.surveyService = surveyService;
@@ -45,106 +52,106 @@ public class UserController {
 
     @Operation(summary = "사용자 정보 조회", description = "요청한 사용자의 정보를 가져옵니다.")
     @ApiResponses(value = {
-            @ApiResponse(responseCode = "200", description = "요청 성공"),
-            @ApiResponse(responseCode = "400", description = "잘못된 요청", content = @Content(schema = @Schema(hidden = true))),
-            @ApiResponse(responseCode = "401", description = "사용자 인증 실패", content = @Content(schema = @Schema(hidden = true))),
-            @ApiResponse(responseCode = "403", description = "접근 권한 없음", content = @Content(schema = @Schema(hidden = true))),
-            @ApiResponse(responseCode = "404", description = "요청한 리소스 찾을 수 없음", content = @Content(schema = @Schema(hidden = true)))
+        @ApiResponse(responseCode = "200", description = "요청 성공"),
+        @ApiResponse(responseCode = "400", description = "잘못된 요청", content = @Content(schema = @Schema(hidden = true))),
+        @ApiResponse(responseCode = "401", description = "사용자 인증 실패", content = @Content(schema = @Schema(hidden = true))),
+        @ApiResponse(responseCode = "403", description = "접근 권한 없음", content = @Content(schema = @Schema(hidden = true))),
+        @ApiResponse(responseCode = "404", description = "요청한 리소스 찾을 수 없음", content = @Content(schema = @Schema(hidden = true)))
     })
     @GetMapping("/profile")
     public ResponseEntity<UserResponseDto> getUserProfile(
-            @Parameter(hidden = true) Authentication authentication) {
+        @Parameter(hidden = true) Authentication authentication) {
         return ResponseEntity.ok(userService.getUserProfile(authentication));
     }
 
     @Operation(summary = "사용자 설문조사 목록 조회", description = "사용자가 생성한 설문조사 목록을 가져옵니다.")
     @ApiResponses(value = {
-            @ApiResponse(responseCode = "200", description = "요청 성공"),
-            @ApiResponse(responseCode = "400", description = "잘못된 요청", content = @Content(schema = @Schema(hidden = true))),
-            @ApiResponse(responseCode = "401", description = "사용자 인증 실패", content = @Content(schema = @Schema(hidden = true))),
-            @ApiResponse(responseCode = "403", description = "접근 권한 없음", content = @Content(schema = @Schema(hidden = true))),
-            @ApiResponse(responseCode = "404", description = "요청한 리소스 찾을 수 없음", content = @Content(schema = @Schema(hidden = true)))
+        @ApiResponse(responseCode = "200", description = "요청 성공"),
+        @ApiResponse(responseCode = "400", description = "잘못된 요청", content = @Content(schema = @Schema(hidden = true))),
+        @ApiResponse(responseCode = "401", description = "사용자 인증 실패", content = @Content(schema = @Schema(hidden = true))),
+        @ApiResponse(responseCode = "403", description = "접근 권한 없음", content = @Content(schema = @Schema(hidden = true))),
+        @ApiResponse(responseCode = "404", description = "요청한 리소스 찾을 수 없음", content = @Content(schema = @Schema(hidden = true)))
     })
     @GetMapping("/surveys")
-    public ResponseEntity<List<UserSurveyTitleDto>> getUserCreatedSurveys(
-            @Parameter(hidden = true) Authentication authentication) {
+    public ResponseEntity<UserSurveyTitleListDto> getUserCreatedSurveys(
+        @Parameter(hidden = true) Authentication authentication) {
         return ResponseEntity.ok(surveyService.getUserCreatedSurveys(authentication));
     }
 
     @Operation(summary = "사용자 설문조사 결과 조회", description = "사용자가 생성한 설문조사 결과를 가져옵니다.")
     @ApiResponses(value = {
-            @ApiResponse(responseCode = "200", description = "요청 성공"),
-            @ApiResponse(responseCode = "400", description = "잘못된 요청", content = @Content(schema = @Schema(hidden = true))),
-            @ApiResponse(responseCode = "401", description = "사용자 인증 실패", content = @Content(schema = @Schema(hidden = true))),
-            @ApiResponse(responseCode = "403", description = "접근 권한 없음", content = @Content(schema = @Schema(hidden = true))),
-            @ApiResponse(responseCode = "404", description = "요청한 리소스 찾을 수 없음", content = @Content(schema = @Schema(hidden = true)))
+        @ApiResponse(responseCode = "200", description = "요청 성공"),
+        @ApiResponse(responseCode = "400", description = "잘못된 요청", content = @Content(schema = @Schema(hidden = true))),
+        @ApiResponse(responseCode = "401", description = "사용자 인증 실패", content = @Content(schema = @Schema(hidden = true))),
+        @ApiResponse(responseCode = "403", description = "접근 권한 없음", content = @Content(schema = @Schema(hidden = true))),
+        @ApiResponse(responseCode = "404", description = "요청한 리소스 찾을 수 없음", content = @Content(schema = @Schema(hidden = true)))
     })
     @GetMapping("/surveys/{surveyId}")
     public ResponseEntity<UserSurveyResultDto> getUserCreatedSurveyResult(
-            @Parameter(hidden = true) Authentication authentication,
-            @PathVariable("surveyId") UUID surveyId) {
+        @Parameter(hidden = true) Authentication authentication,
+        @PathVariable("surveyId") UUID surveyId) {
         return ResponseEntity.ok(
-                surveyService.getUserCreatedSurveyResult(authentication, surveyId));
+            surveyService.getUserCreatedSurveyResult(authentication, surveyId));
     }
 
     @Operation(summary = "사용자 정보 수정", description = "요청한 사용자의 정보를 수정합니다.")
     @ApiResponses(value = {
-            @ApiResponse(responseCode = "200", description = "요청 성공"),
-            @ApiResponse(responseCode = "400", description = "잘못된 요청", content = @Content(schema = @Schema(hidden = true))),
-            @ApiResponse(responseCode = "401", description = "사용자 인증 실패", content = @Content(schema = @Schema(hidden = true))),
-            @ApiResponse(responseCode = "403", description = "접근 권한 없음", content = @Content(schema = @Schema(hidden = true))),
-            @ApiResponse(responseCode = "404", description = "요청한 리소스 찾을 수 없음", content = @Content(schema = @Schema(hidden = true)))
+        @ApiResponse(responseCode = "200", description = "요청 성공"),
+        @ApiResponse(responseCode = "400", description = "잘못된 요청", content = @Content(schema = @Schema(hidden = true))),
+        @ApiResponse(responseCode = "401", description = "사용자 인증 실패", content = @Content(schema = @Schema(hidden = true))),
+        @ApiResponse(responseCode = "403", description = "접근 권한 없음", content = @Content(schema = @Schema(hidden = true))),
+        @ApiResponse(responseCode = "404", description = "요청한 리소스 찾을 수 없음", content = @Content(schema = @Schema(hidden = true)))
     })
     @PatchMapping("/profile")
     public ResponseEntity<UserResponseDto> updateUserProfile(
-            @Parameter(hidden = true) Authentication authentication,
-            @RequestBody UserUpdateRequestDto userUpdateRequestDto) {
+        @Parameter(hidden = true) Authentication authentication,
+        @RequestBody UserUpdateRequestDto userUpdateRequestDto) {
         return ResponseEntity.ok(
-                userService.updateUserProfile(authentication, userUpdateRequestDto));
+            userService.updateUserProfile(authentication, userUpdateRequestDto));
     }
 
     @Operation(summary = "사용자 인증 정보 조회", description = "사용자의 인증 정보를 조회합니다.")
     @ApiResponses(value = {
-            @ApiResponse(responseCode = "200", description = "요청 성공"),
-            @ApiResponse(responseCode = "400", description = "잘못된 요청", content = @Content(schema = @Schema(hidden = true))),
-            @ApiResponse(responseCode = "401", description = "사용자 인증 실패", content = @Content(schema = @Schema(hidden = true))),
-            @ApiResponse(responseCode = "403", description = "접근 권한 없음", content = @Content(schema = @Schema(hidden = true))),
-            @ApiResponse(responseCode = "404", description = "요청한 리소스 찾을 수 없음", content = @Content(schema = @Schema(hidden = true)))
+        @ApiResponse(responseCode = "200", description = "요청 성공"),
+        @ApiResponse(responseCode = "400", description = "잘못된 요청", content = @Content(schema = @Schema(hidden = true))),
+        @ApiResponse(responseCode = "401", description = "사용자 인증 실패", content = @Content(schema = @Schema(hidden = true))),
+        @ApiResponse(responseCode = "403", description = "접근 권한 없음", content = @Content(schema = @Schema(hidden = true))),
+        @ApiResponse(responseCode = "404", description = "요청한 리소스 찾을 수 없음", content = @Content(schema = @Schema(hidden = true)))
     })
     @GetMapping("/profile/certifications")
     public ResponseEntity<UserCertificationListDto> getUserCertification(
-            @Parameter(hidden = true) Authentication authentication) {
+        @Parameter(hidden = true) Authentication authentication) {
         return ResponseEntity.ok(
-                userCertificationService.getUserCertifications(authentication));
+            userCertificationService.getUserCertifications(authentication));
     }
 
     @Operation(summary = "사용자 인증 정보 수정", description = "사용자의 인증 정보를 수정합니다.")
     @ApiResponses(value = {
-            @ApiResponse(responseCode = "200", description = "요청 성공"),
-            @ApiResponse(responseCode = "400", description = "잘못된 요청", content = @Content(schema = @Schema(hidden = true))),
-            @ApiResponse(responseCode = "401", description = "사용자 인증 실패", content = @Content(schema = @Schema(hidden = true))),
-            @ApiResponse(responseCode = "403", description = "접근 권한 없음", content = @Content(schema = @Schema(hidden = true))),
-            @ApiResponse(responseCode = "404", description = "요청한 리소스 찾을 수 없음", content = @Content(schema = @Schema(hidden = true)))
+        @ApiResponse(responseCode = "200", description = "요청 성공"),
+        @ApiResponse(responseCode = "400", description = "잘못된 요청", content = @Content(schema = @Schema(hidden = true))),
+        @ApiResponse(responseCode = "401", description = "사용자 인증 실패", content = @Content(schema = @Schema(hidden = true))),
+        @ApiResponse(responseCode = "403", description = "접근 권한 없음", content = @Content(schema = @Schema(hidden = true))),
+        @ApiResponse(responseCode = "404", description = "요청한 리소스 찾을 수 없음", content = @Content(schema = @Schema(hidden = true)))
     })
     @PatchMapping("/profile/certifications")
     public ResponseEntity<UserCertificationListDto> updateUserCertification(
-            @Parameter(hidden = true) Authentication authentication,
-            @RequestBody @Valid UserCertificationUpdateRequestDto userCertificationUpdateRequestDto) {
+        @Parameter(hidden = true) Authentication authentication,
+        @RequestBody @Valid UserCertificationUpdateRequestDto userCertificationUpdateRequestDto) {
         return ResponseEntity.ok(
-                userCertificationService.updateUserCertification(authentication, userCertificationUpdateRequestDto));
+            userCertificationService.updateUserCertification(authentication, userCertificationUpdateRequestDto));
     }
 
     @Operation(summary = "사용자 삭제", description = "요청한 사용자의 정보를 삭제합니다.")
     @ApiResponses(value = {
-            @ApiResponse(responseCode = "204", description = "요청 성공"),
-            @ApiResponse(responseCode = "400", description = "잘못된 요청", content = @Content(schema = @Schema(hidden = true))),
-            @ApiResponse(responseCode = "401", description = "사용자 인증 실패", content = @Content(schema = @Schema(hidden = true))),
-            @ApiResponse(responseCode = "403", description = "접근 권한 없음", content = @Content(schema = @Schema(hidden = true))),
-            @ApiResponse(responseCode = "404", description = "요청한 리소스 찾을 수 없음", content = @Content(schema = @Schema(hidden = true)))
+        @ApiResponse(responseCode = "204", description = "요청 성공"),
+        @ApiResponse(responseCode = "400", description = "잘못된 요청", content = @Content(schema = @Schema(hidden = true))),
+        @ApiResponse(responseCode = "401", description = "사용자 인증 실패", content = @Content(schema = @Schema(hidden = true))),
+        @ApiResponse(responseCode = "403", description = "접근 권한 없음", content = @Content(schema = @Schema(hidden = true))),
+        @ApiResponse(responseCode = "404", description = "요청한 리소스 찾을 수 없음", content = @Content(schema = @Schema(hidden = true)))
     })
     @DeleteMapping
     public ResponseEntity<Void> deleteUser(
-            @Parameter(hidden = true) Authentication authentication) {
+        @Parameter(hidden = true) Authentication authentication) {
         userService.deleteUser(authentication);
         return ResponseEntity.status(HttpStatus.NO_CONTENT).build();
     }

--- a/api/src/main/java/com/thesurvey/api/dto/response/user/UserSurveyTitleListDto.java
+++ b/api/src/main/java/com/thesurvey/api/dto/response/user/UserSurveyTitleListDto.java
@@ -1,0 +1,14 @@
+package com.thesurvey.api.dto.response.user;
+
+import java.util.List;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class UserSurveyTitleListDto {
+
+    private List<UserSurveyTitleDto> surveys;
+
+}

--- a/api/src/main/java/com/thesurvey/api/service/SurveyService.java
+++ b/api/src/main/java/com/thesurvey/api/service/SurveyService.java
@@ -21,7 +21,7 @@ import com.thesurvey.api.dto.response.survey.SurveyListPageDto;
 import com.thesurvey.api.dto.response.survey.SurveyPageDto;
 import com.thesurvey.api.dto.response.survey.SurveyResponseDto;
 import com.thesurvey.api.dto.response.user.UserSurveyResultDto;
-import com.thesurvey.api.dto.response.user.UserSurveyTitleDto;
+import com.thesurvey.api.dto.response.user.UserSurveyTitleListDto;
 import com.thesurvey.api.exception.ErrorMessage;
 import com.thesurvey.api.exception.mapper.BadRequestExceptionMapper;
 import com.thesurvey.api.exception.mapper.ForbiddenRequestExceptionMapper;
@@ -114,9 +114,11 @@ public class SurveyService {
     }
 
     @Transactional(readOnly = true)
-    public List<UserSurveyTitleDto> getUserCreatedSurveys(Authentication authentication) {
-        return surveyRepository.findUserCreatedSurveysByAuthorID(
-            UserUtil.getUserIdFromAuthentication(authentication));
+    public UserSurveyTitleListDto getUserCreatedSurveys(Authentication authentication) {
+        return UserSurveyTitleListDto.builder()
+            .surveys(surveyRepository.findUserCreatedSurveysByAuthorID(
+                UserUtil.getUserIdFromAuthentication(authentication)))
+            .build();
     }
 
     /**

--- a/api/src/test/java/com/thesurvey/api/controller/UserControllerTest.java
+++ b/api/src/test/java/com/thesurvey/api/controller/UserControllerTest.java
@@ -160,8 +160,9 @@ public class UserControllerTest extends BaseControllerTest {
                 .with(authentication(authentication)))
             .andExpect(status().isOk())
             .andReturn();
-        JSONArray content = new JSONArray(result.getResponse().getContentAsString());
-        JSONObject userCreatedSurvey = content.getJSONObject(0);
+        JSONObject content = new JSONObject(result.getResponse().getContentAsString());
+        JSONArray userCreatedSurveyList = content.getJSONArray("surveys");
+        JSONObject userCreatedSurvey = userCreatedSurveyList.getJSONObject(0);
 
         // then
         assertThat(content.length()).isEqualTo(1);


### PR DESCRIPTION
이 PR은 사용자가 생성한 설문조사 리스트 요청 시 
JSON 포맷 변경을 수행합니다.

수행한 이유는 다음과 같습니다.
- 프론트엔드에서 설문조사 리스트를 매핑하는데 key 값이 따로 없어서 불편함
- 데이터를 매핑하는데 typescript에서 이를 바로 리스트로 받아드리지 못해서 매핑이 안됨

**변경 사항**
- `UserSurveyTitleListDto.java` 는 설문조사 `ID`와 `title`를 포함하는 `UserSurveyTitleDto`의 리스트입니다.
- `UserController.java`에서 `getUserCreatedSurveys`의 리턴 타입을 `UserSurveyTitleListDto`로 변경하였습니다.

**이전 JSON 포맷**
```
[
  {
    "surveyId": "93c0a231-207e-4190-aee9-0a5f78cafc44",
    "title": "카카오 사용자분들께 설문 부탁드립니다!"
  }
]
```

**변경된 JSON 포맷**
```
{
    "surveys": [
        {
            "surveyId": "93c0a231-207e-4190-aee9-0a5f78cafc44",
            "title": "카카오 사용자분들께 설문 부탁드립니다!"
        }
    ]
}
```