### PR TITLE
fix: 사용자 인증 만료를 검사하는 메소드에서 `@Scheduled` 어노테이션에 기준 시간대 설정

### DIFF
--- a/api/src/main/java/com/thesurvey/api/service/UserCertificationService.java
+++ b/api/src/main/java/com/thesurvey/api/service/UserCertificationService.java
@@ -1,5 +1,9 @@
 package com.thesurvey.api.service;
 
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.util.List;
+
 import com.thesurvey.api.domain.EnumTypeEntity.CertificationType;
 import com.thesurvey.api.domain.User;
 import com.thesurvey.api.domain.UserCertification;
@@ -8,10 +12,6 @@ import com.thesurvey.api.dto.response.userCertification.UserCertificationListDto
 import com.thesurvey.api.repository.UserCertificationRepository;
 import com.thesurvey.api.service.mapper.UserCertificationMapper;
 import com.thesurvey.api.util.UserUtil;
-
-import java.time.LocalDateTime;
-import java.time.ZoneId;
-import java.util.List;
 
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.security.core.Authentication;
@@ -75,7 +75,7 @@ public class UserCertificationService {
      * This method is a scheduled task that runs every day at midnight
      * (in the "Asia/Seoul" timezone) to delete expired user certifications from the database.
      */
-    @Scheduled(cron = "0 0 0 * * ?")
+    @Scheduled(cron = "0 0 0 * * ?", zone = "Asia/Seoul")
     public void deleteExpiredCertificates() {
         userCertificationRepository.deleteByExpirationDateLessThanEqual(
             LocalDateTime.now(ZoneId.of("Asia/Seoul")));


### PR DESCRIPTION
### 변경 사항
사용자 인증 만료 기한을 검사하는 `deleteExpiredCertificates` 메소드에서
`@Scheduled` 어노테이션에 기준 시간을 _"Asia/Seoul"_ 로 명시해주었습니다.