### PR TITLE
fix: 에러 메세지에서 중복되는 문자 삭제, 로그인 상태관리

### DIFF
--- a/web/src/components/ErrorPage.tsx
+++ b/web/src/components/ErrorPage.tsx
@@ -86,7 +86,7 @@ export default function ErrorPage({ labelText, buttonText, navigateRoute, theme,
     <Container theme={theme}>
       <Header theme={theme} toggleTheme={toggleTheme} />
       <ErrorContainer theme={theme}>
-        {labelText === '😥 앗! 아직 설문을 만들지 않았어요.' && (
+        {labelText === '앗! 아직 설문을 만들지 않았어요.' && (
           <ErrorPageTitle style={{ marginBottom: '5vh' }} theme={theme}>
             <MypageText theme={theme} onClick={() => updateUserInformation(dispatch, navigate)}>
               마이페이지
@@ -95,7 +95,7 @@ export default function ErrorPage({ labelText, buttonText, navigateRoute, theme,
           </ErrorPageTitle>
         )}
         <Notification theme={theme}>
-          <Label theme={theme}>{labelText}</Label>
+          <Label theme={theme}>{`😥 ${labelText}`}</Label>
           <br />
           <RectangleButton
             text={buttonText}

--- a/web/src/components/ErrorPage.tsx
+++ b/web/src/components/ErrorPage.tsx
@@ -95,7 +95,7 @@ export default function ErrorPage({ labelText, buttonText, navigateRoute, theme,
           </ErrorPageTitle>
         )}
         <Notification theme={theme}>
-          <Label theme={theme}>{`😥 ${labelText}`}</Label>
+          <Label theme={theme}>{`😥 ${labelText}..`}</Label>
           <br />
           <RectangleButton
             text={buttonText}

--- a/web/src/components/Modal/HeaderModal.tsx
+++ b/web/src/components/Modal/HeaderModal.tsx
@@ -28,6 +28,7 @@ const SubPageContainer = styled.div`
   overflow-y: auto;
   border: ${(props) => props.theme.borderResultList};
   border-radius: ${(props) => props.theme.borderRadius};
+
   & > * {
     margin-bottom: 10px;
   }
@@ -60,8 +61,8 @@ export default function Header({ theme }: HeaderProps) {
   const dispatch = useDispatch();
 
   const logoutClick = () => {
-    dispatch(setLoggedIn(!isLoggedIn));
-    dispatch(setSubPageOpen(!isSubPageOpen));
+    dispatch(setLoggedIn(false));
+    dispatch(setSubPageOpen(false));
     clearUserInformation(dispatch);
     navigate('../../../');
   };

--- a/web/src/components/SurveyCreateForm/SurveyCreateForm.tsx
+++ b/web/src/components/SurveyCreateForm/SurveyCreateForm.tsx
@@ -1,6 +1,5 @@
 import React, { useEffect, useRef, useState } from 'react';
 
-import { useDispatch } from 'react-redux';
 import styled, { DefaultTheme } from 'styled-components';
 
 import axios from '../../api/axios';

--- a/web/src/components/SurveyCreateForm/SurveyCreateForm.tsx
+++ b/web/src/components/SurveyCreateForm/SurveyCreateForm.tsx
@@ -43,7 +43,6 @@ interface SurveyFormProps {
 }
 
 export default function SurveyCreateForm({ theme }: SurveyFormProps) {
-  const dispatch = useDispatch();
   const questionRefs = useRef<HTMLDivElement[]>([]);
   const [recentCreate, setRecentCreate] = useState<number>();
   const [certificationIsChecked, setCertificationIsChecked] = useState<boolean>(false);
@@ -71,7 +70,7 @@ export default function SurveyCreateForm({ theme }: SurveyFormProps) {
         setResultModalOpen(true);
       })
       .catch((error) => {
-        const errorMessages: string[] = responseErrorHandle(error, dispatch);
+        const errorMessages: string[] = responseErrorHandle(error);
         setWarnText(errorMessages[0]);
         setAlertModalOpen(true);
         setConfirmModalOpen(false);

--- a/web/src/components/SurveyParticipateForm/SurveyParticipateForm.tsx
+++ b/web/src/components/SurveyParticipateForm/SurveyParticipateForm.tsx
@@ -1,6 +1,5 @@
 import React, { useEffect, useMemo, useRef, useState } from 'react';
 
-import { useDispatch } from 'react-redux';
 import styled, { DefaultTheme } from 'styled-components';
 
 import axios from '../../api/axios';

--- a/web/src/components/SurveyParticipateForm/SurveyParticipateForm.tsx
+++ b/web/src/components/SurveyParticipateForm/SurveyParticipateForm.tsx
@@ -68,7 +68,6 @@ interface SurveyParticipateFormProps {
 }
 
 export default function SurveyParticipateForm({ surveyData, theme }: SurveyParticipateFormProps) {
-  const dispatch = useDispatch();
   const questionRefs = useRef<HTMLDivElement[]>([]);
   const [endedDate, setEndedDate] = useState<string>('');
   const [resultModalOpen, setResultModalOpen] = useState<boolean>(false);
@@ -93,7 +92,7 @@ export default function SurveyParticipateForm({ surveyData, theme }: SurveyParti
         setConfirmModalOpen(false);
       })
       .catch((error) => {
-        const errorMessages: string[] = responseErrorHandle(error, dispatch);
+        const errorMessages: string[] = responseErrorHandle(error);
         setWarnText(errorMessages[0]);
         setAlertModalOpen(true);
         setConfirmModalOpen(false);

--- a/web/src/reducers/header.ts
+++ b/web/src/reducers/header.ts
@@ -20,9 +20,9 @@ const initialAction: HeaderAction = {
 export const headerReducer = (state: HeaderState = initialState, action: HeaderAction = initialAction): HeaderState => {
   switch (action.type) {
     case 'SET_LOGGED_IN':
-      return { ...state, isLoggedIn: !state.isLoggedIn };
+      return { ...state, isLoggedIn: action.payload };
     case 'SETSUBPAGE':
-      return { ...state, isSubPageOpen: !state.isSubPageOpen };
+      return { ...state, isSubPageOpen: action.payload };
     default:
       return state;
   }

--- a/web/src/routes/MyPages/ProfilePage.tsx
+++ b/web/src/routes/MyPages/ProfilePage.tsx
@@ -212,7 +212,7 @@ export default function ProfilePage() {
   };
 
   const navigateAuthListPage = () => {
-    dispatch(setSubPageOpen(!isSubPageOpen));
+    dispatch(setSubPageOpen(false));
     axios
       .get<UserAuthListResponse>(requests.getUserAuthList)
       .then((getAuthListResponse) => {

--- a/web/src/routes/MyPages/SurveyResultPage.tsx
+++ b/web/src/routes/MyPages/SurveyResultPage.tsx
@@ -168,10 +168,10 @@ export default function SurveyResultPage() {
     return <LoadingForm />;
   }
 
-  if (isError || data === undefined) {
+  if (isError || data === undefined || data.length === 0) {
     return (
       <ErrorPage
-        labelText="😥 앗! 아직 설문을 만들지 않았어요."
+        labelText="앗! 아직 설문을 만들지 않았어요."
         buttonText="설문 만들러 가기"
         navigateRoute="/survey/form"
         theme={theme}

--- a/web/src/routes/SurveyPages/SurveyListPage.tsx
+++ b/web/src/routes/SurveyPages/SurveyListPage.tsx
@@ -2,7 +2,6 @@ import React, { useEffect, useState } from 'react';
 
 import { useQuery } from '@tanstack/react-query';
 import { AxiosError } from 'axios';
-import { useDispatch } from 'react-redux';
 import styled from 'styled-components';
 
 import { fetchSurveyList } from '../../api/fetchFunctions';
@@ -74,7 +73,7 @@ export default function SurveyListPage() {
   if (data.surveys.length === 0) {
     return (
       <ErrorPage
-        labelText="😥 앗! 아직 참여 가능한 설문이 없어요..."
+        labelText="앗! 아직 참여 가능한 설문이 없어요..."
         buttonText="설문 만들러 가기"
         navigateRoute="/survey/form"
         theme={theme}

--- a/web/src/routes/SurveyPages/SurveyListPage.tsx
+++ b/web/src/routes/SurveyPages/SurveyListPage.tsx
@@ -25,7 +25,6 @@ const Container = styled.div`
 const ListContainer = styled.div``;
 
 export default function SurveyListPage() {
-  const dispatch = useDispatch();
   const [theme, toggleTheme] = useTheme();
   const [page, setPage] = useState<number>(1);
   const [previewModalOpen, setPreviewModalOpen] = useState<boolean>(false);
@@ -43,9 +42,9 @@ export default function SurveyListPage() {
 
   useEffect(() => {
     if (isError) {
-      const errorMessages: string[] = responseErrorHandle(error as AxiosError, dispatch);
+      const errorMessages: string[] = responseErrorHandle(error as AxiosError);
 
-      setErrorLabel(`😥 ${errorMessages[0]}..`);
+      setErrorLabel(`${errorMessages[0]}`);
       setErrorButtonText(errorMessages[1]);
       setErrorNavigate(errorMessages[2]);
     }

--- a/web/src/routes/SurveyPages/SurveyPage.tsx
+++ b/web/src/routes/SurveyPages/SurveyPage.tsx
@@ -2,7 +2,6 @@ import React, { useEffect, useState } from 'react';
 
 import { useQuery } from '@tanstack/react-query';
 import { AxiosError } from 'axios';
-import { useDispatch } from 'react-redux';
 import { useParams } from 'react-router-dom';
 import styled from 'styled-components';
 

--- a/web/src/routes/SurveyPages/SurveyPage.tsx
+++ b/web/src/routes/SurveyPages/SurveyPage.tsx
@@ -28,7 +28,6 @@ export default function SurveyPage() {
   const [errorLabel, setErrorLabel] = useState<string>('');
   const [errorButtonText, setErrorButtonText] = useState<string>('');
   const [errorNavigate, setErrorNavigate] = useState<string>('');
-  const dispatch = useDispatch();
 
   const { data, isLoading, isError, error } = useQuery<SurveyResponse>(['survey', id], fetchSurveyData, {
     cacheTime: 15 * 60 * 1000, // 15 minutes
@@ -39,9 +38,9 @@ export default function SurveyPage() {
 
   useEffect(() => {
     if (isError) {
-      const errorMessages: string[] = responseErrorHandle(error as AxiosError, dispatch);
+      const errorMessages: string[] = responseErrorHandle(error as AxiosError);
 
-      setErrorLabel(`😥 ${errorMessages[0]}..`);
+      setErrorLabel(`${errorMessages[0]}`);
       setErrorButtonText(errorMessages[1]);
       setErrorNavigate(errorMessages[2]);
     }

--- a/web/src/utils/responseErrorHandle.ts
+++ b/web/src/utils/responseErrorHandle.ts
@@ -4,8 +4,8 @@ export const responseErrorHandle = (error: AxiosError): string[] => {
   const { response } = error as AxiosError;
 
   let labelText = typeof response?.data === 'string' ? response.data : '';
-  let buttonText = '';
-  let navigateRoute = '';
+  let buttonText = '홈화면으로 돌아가기';
+  let navigateRoute = '/';
 
   switch (response?.status) {
     case 400:
@@ -13,21 +13,17 @@ export const responseErrorHandle = (error: AxiosError): string[] => {
         buttonText = '확인';
       } else {
         labelText = '잘못된 요청이에요. 다시 시도 해주세요.';
-        buttonText = '홈화면으로 돌아가기';
-        navigateRoute = '/';
       }
       break;
     case 401:
       if (labelText === '설문조사에 필요한 인증을 하지 않았습니다.') {
+        labelText = '설문조사에 필요한 인증을 완료 해주세요.';
         buttonText = '인증 하러 가기';
         navigateRoute = '/mypage/auth-list';
       } else if (labelText === '권한이 없습니다.') {
         labelText = '로그인이 만료 되었어요.';
         buttonText = '로그인 하러 가기';
         navigateRoute = '/login';
-      } else {
-        buttonText = '홈화면으로 돌아가기';
-        navigateRoute = '/';
       }
       break;
     case 403:
@@ -36,12 +32,9 @@ export const responseErrorHandle = (error: AxiosError): string[] => {
       break;
     case 500:
       labelText = '앗! 서버에 문제가 생겼어요.';
-      navigateRoute = '/';
       break;
     default:
       labelText = `${response?.status} 에러가 발생했어요.`;
-      buttonText = '홈화면으로 돌아가기';
-      navigateRoute = '/';
       break;
   }
 

--- a/web/src/utils/responseErrorHandle.ts
+++ b/web/src/utils/responseErrorHandle.ts
@@ -1,9 +1,6 @@
 import { AxiosError } from 'axios';
-import { Dispatch } from 'redux';
 
-import { setLoggedIn, HeaderAction } from '../types/header';
-
-export const responseErrorHandle = (error: AxiosError, dispatch: Dispatch<HeaderAction>): string[] => {
+export const responseErrorHandle = (error: AxiosError): string[] => {
   const { response } = error as AxiosError;
 
   let labelText = typeof response?.data === 'string' ? response.data : '';
@@ -28,6 +25,9 @@ export const responseErrorHandle = (error: AxiosError, dispatch: Dispatch<Header
         labelText = '로그인이 만료 되었어요.';
         buttonText = '로그인 하러 가기';
         navigateRoute = '/login';
+      } else {
+        buttonText = '홈화면으로 돌아가기';
+        navigateRoute = '/';
       }
       break;
     case 403:


### PR DESCRIPTION
1. 에러 메세지에서 중복되는 문자('😥' , '..') 삭제
> ErrorPage에 추가
2. 로그인, 서브페이지 상태관리 제대로 안되는 문제 수정
> `return { ...state, isSubPageOpen: !state.isSubPageOpen };`
> to
> `return { ...state, isSubPageOpen: action.payload };`
